### PR TITLE
Fix Bloom breaking completely when forcing float16 buffers

### DIFF
--- a/Extra/Shaders/NewVegasReloaded/Effects/Bloom.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Bloom.fx.hlsl
@@ -101,7 +101,7 @@ float4 BlurPass(VSOUT IN, uniform float2 OffsetMask) : COLOR0
 
 float4 CombinePass(VSOUT IN) : COLOR0
 {
-	float3 bloomColor = tex2D(TESR_RenderedBuffer, IN.UVCoord).rgb;
+	float3 bloomColor = saturate(tex2D(TESR_RenderedBuffer, IN.UVCoord).rgb);
 	float3 originalColor = tex2D(TESR_SourceBuffer, IN.UVCoord).rgb;
 	
 	bloomColor = AdjustSaturation(bloomColor, TESR_BloomValues.z) * TESR_BloomValues.x;


### PR DESCRIPTION
Activating bloom in NVR when using a DXVK fork that replaces textures from int8 to float16 completely breaks the image (it looks like a burned picture, red and black).

I'm not 100% sure clamping the texture between 0-1 is a bloom responsbility, or if the ```TESR_RenderedBuffer``` was already broken when it reached there, but this works fine. Potentially, the ```AdjustSaturation(bloomColor, ...)``` call boosts up its color over 1 even more, and then again that's not clipped when forcing float16 buffers, so it creates even more problems.