### PR TITLE
Fix all luminance formulas I could find

### DIFF
--- a/Extra/Shaders/NewVegasReloaded/Effects/Bloom.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Bloom.fx.hlsl
@@ -70,7 +70,7 @@ static const float2 BlurOffsets[cKernelSize] =
 
 float3 AdjustSaturation(float3 color, float saturation)
 {
-	float grey = dot(color, float3(0.3, 0.59, 0.11));
+	float grey = dot(color, float3(0.2126, 0.7152, 0.0722));
 	
 	return lerp(grey, color, saturation);
 }

--- a/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blending.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blending.hlsl
@@ -5,7 +5,7 @@ float4 alphaBlend(float4 base, float4 blend)
 
 float Luma(float4 input)
 {
-	float greyscale = input.r * 0.3f + input.g * 0.59f +input.b * 0.11f;
+	float greyscale = input.r * 0.2126f + input.g * 0.7152f +input.b * 0.0722f;
 	return greyscale;
 }
 

--- a/Extra/Shaders/NewVegasReloaded/Effects/LowHF.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/LowHF.fx.hlsl
@@ -4,7 +4,7 @@ float4 TESR_LowHFData;
 
 sampler2D TESR_RenderedBuffer : register(s0) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 
-static const float3 LuminanceConv = { 0.2125f, 0.7154f, 0.0721f };
+static const float3 LuminanceConv = { 0.2126f, 0.7152f, 0.0722f };
 
 struct VSOUT
 {

--- a/Extra/Shaders/NewVegasReloaded/Effects/ShadowsInteriors.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/ShadowsInteriors.fx.hlsl
@@ -154,7 +154,7 @@ float4 Shadow( VSOUT IN ) : COLOR0 {
 
 float Luma(float3 input)
 {
-	return input.r * 0.3f + input.g * 0.59f +input.b * 0.11f;
+	return input.r * 0.2126f + input.g * 0.7152f +input.b * 0.0722f;
 }
 
 float4 CombineShadow( VSOUT IN ) : COLOR0 {

--- a/Extra/Shaders/NewVegasReloaded/Effects/VolumetricFog.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/VolumetricFog.fx.hlsl
@@ -55,7 +55,7 @@ float ExponentialFog(float posHeight, float distance) {
 
 float Luma(float3 input)
 {
-	return input.r * 0.3f + input.g * 0.59f +input.b * 0.11f;
+	return input.r * 0.2126f + input.g * 0.7152f +input.b * 0.0722f;
 }
 
 float4 VolumetricFog(VSOUT IN) : COLOR0 {

--- a/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCINAM.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCINAM.pso.hlsl
@@ -44,7 +44,7 @@ struct VS_OUTPUT {
 VS_OUTPUT main(VS_INPUT IN) {
     VS_OUTPUT OUT;
 
-    const float4 const_0 = {0.299, 0.587000012, 0.114, 0};
+    const float4 const_0 = {0.2126, 0.7152, 0.0722, 0}; // BT.709 luma vector
 
     float1 q0;
     float3 q1;

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Helpers.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Helpers.hlsl
@@ -3,7 +3,7 @@
 #define	shade(n, l)         max(dot(n, l), 0)
 #define	shades(n, l)        saturate(dot(n, l))
 #define invlerp(a, b, t)    (t-a)/(b-a)
-#define luma(color)         color.r * 0.3f + color.g * 0.59f +color.b * 0.11f; // extract luma
+#define luma(color)         color.r * 0.2126f + color.g * 0.7152f +color.b * 0.0722f; // extract luma (BT.709)
 #define mix(colora, colorb) colora * colorb * 2 // mix two colors without darkening
 #define	weight(v)           dot(v, 1)
 #define	sqr(v)              ((v) * (v))

--- a/Extra/Shaders/OblivionReloaded/Effects/AmbientOcclusion.fx.hlsl
+++ b/Extra/Shaders/OblivionReloaded/Effects/AmbientOcclusion.fx.hlsl
@@ -206,7 +206,7 @@ float4 Combine(VSOUT IN) : COLOR0
 {
 	float3 color = tex2D(TESR_SourceBuffer, IN.UVCoord).rgb;
 	float ao = tex2D(TESR_RenderedBuffer, IN.UVCoord).r;
-	float luminance = color.r * 0.3 + color.g * 0.59 + color.b * 0.11;
+	float luminance = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
 	float white = 1.0;
 	float black = 0.0;
 	float lt = luminance - TESR_AmbientOcclusionData.y;

--- a/Extra/Shaders/OblivionReloaded/Effects/Bloom.fx.hlsl
+++ b/Extra/Shaders/OblivionReloaded/Effects/Bloom.fx.hlsl
@@ -70,7 +70,7 @@ static const float2 BlurOffsets[cKernelSize] =
 
 float3 AdjustSaturation(float3 color, float saturation)
 {
-	float grey = dot(color, float3(0.3, 0.59, 0.11));
+	float grey = dot(color, float3(0.2126, 0.7152, 0.0722));
 	
 	return lerp(grey, color, saturation);
 }

--- a/Extra/Shaders/OblivionReloaded/Effects/LowHF.fx.hlsl
+++ b/Extra/Shaders/OblivionReloaded/Effects/LowHF.fx.hlsl
@@ -4,7 +4,7 @@ float4 TESR_LowHFData;
 
 sampler2D TESR_RenderedBuffer : register(s0) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 
-static const float3 LuminanceConv = { 0.2125f, 0.7154f, 0.0721f };
+static const float3 LuminanceConv = { 0.2126f, 0.7152f, 0.0722f };
 
 struct VSOUT
 {

--- a/Extra/Shaders/OblivionReloaded/Effects/ShadowsExteriors.fx.hlsl
+++ b/Extra/Shaders/OblivionReloaded/Effects/ShadowsExteriors.fx.hlsl
@@ -214,7 +214,7 @@ float4 alphaBlend(float4 base, float4 blend)
 
 float4 Desaturate(float4 input)
 {
-	float greyscale = input.r * 0.3f + input.g * 0.59f +input.b * 0.11f;
+	float greyscale = input.r * 0.2126f + input.g * 0.7152f +input.b * 0.0722f;
 	return float4(greyscale, greyscale, greyscale, input.a);
 }
 

--- a/Extra/Shaders/OblivionReloaded/Shaders/Includes/Common.hlsl
+++ b/Extra/Shaders/OblivionReloaded/Shaders/Includes/Common.hlsl
@@ -18,7 +18,7 @@ float3 screen(float3 a, float3 b, float w) {
 }
 
 float get_average(float3 col) {
-	return dot(col, 0.333);
+	return dot(col, 0.33333333);
 }
 
 float get_luminosity(float3 col) {
@@ -26,7 +26,7 @@ float get_luminosity(float3 col) {
 }
 
 float get_luma(float3 col) {
-	return max(dot(col, float3(0.299, 0.587, 0.114)), 0.001);
+	return max(dot(col, float3(0.2126, 0.7152, 0.0722)), 0.001);
 }
 
 float get_luma_linear(float3 col) {


### PR DESCRIPTION
The "XYZ_RGB" matrices remain very very very slightly different (like 0.212671 vs 0.2126) from the luma vector I used though it shouldn't really matter.

As previously discussed, the game was using the BT.601 luminance formula all around, instead of the BT.709, which is the color space it actually uses. Likely a mistake that carried over from the 90s.
Mind that many game shaders still use the wrong luminance formula even with these fixes.