### PR TITLE
Fix light overblowing to white when forcing float16 buffers with DXVK

### DIFF
--- a/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
@@ -305,6 +305,9 @@ float4 Shadow(VSOUT IN) : COLOR0
 
 	// brighten shadow value from 0 to darkness from config value
 	Shadow = lerp(darkness, 1.0f, Shadow);
+	
+	// No point for the shadow buffer to be beyond the 0-1 range
+	Shadow = saturate(Shadow);
 
 	// Shadow * (world_pos.z < TESR_WaterSettings.x); // cancel shadow value if under water
 	return float4(Shadow, Shadow, Shadow, 1.0f);

--- a/Extra/Shaders/NewVegasReloaded/Effects/ShadowsInteriors.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/ShadowsInteriors.fx.hlsl
@@ -147,6 +147,8 @@ float4 Shadow( VSOUT IN ) : COLOR0 {
 	Shadow += GetLightAmount(TESR_ShadowCubeMapBuffer11, pos, TESR_ShadowLightPosition11, normal, TESR_LightAttenuation7);
 
 	Shadow = lerp(Shadow, 1.0, saturate(invLerp(300, MAXDISTANCE, depth))); // fade shadows with distance
+
+	Shadow = saturate(Shadow);
 	
 	return float4(Shadow, Shadow, Shadow, 1.0f);
 	


### PR DESCRIPTION
The ```Shadow += attenuation(world_pos, TESR_LightPosition0)``` calls above were making ```float Shadow``` go way beyond 1 (which meant: "no shadow", while a value of 0 is "full shadow") effectively making it add light when it was writing on float16 buffers.
The issue only appears when playing in "scRGB HDR" with custom builds of DXVK, as they change rendering targets from int8 to float 16 (thus allowing values beyond the 0-1 range).

The fix is only "needed" on exterior shadows, but I've also applied it to interior ones, given they follow the same logic (reads from the interiors shadow buffer were already clamped between 0 and 1, but clamping the buffer on writing should be even better).