### PR TITLE
Fix build issues

### DIFF
--- a/TESReloaded/Core/Hooks/Oblivion/Render.cpp
+++ b/TESReloaded/Core/Hooks/Oblivion/Render.cpp
@@ -255,7 +255,7 @@ void* __fastcall ShowDetectorWindowHook(DetectorWindow* This, UInt32 edx, HWND H
 	NiAVObject* Object = NULL;
 	void* r = NULL;
 
-	r = (ShowDetectorWindow)(This, Handle, Instance, RootNode, "Pipeline detector by Alenet", X, Y, 1280, 1024);
+	r = (ShowDetectorWindow)(This, Handle, Instance, RootNode, (char*)"Pipeline detector by Alenet", X, Y, 1280, 1024);
 	for (int i = 0; i < RootNode->m_children.end; i++) {
 		NiNode* Node = (NiNode*)RootNode->m_children.data[i];
 		Node->m_children.data[0] = NULL;

--- a/TESReloaded/Core/OcclusionManager.cpp
+++ b/TESReloaded/Core/OcclusionManager.cpp
@@ -9,11 +9,11 @@ void OcclusionManager::Initialize() {
 	UINT OcclusionMapSizeX = TheRenderManager->width / TheSettingManager->SettingsMain.OcclusionCulling.OcclusionMapRatio;
 	UINT OcclusionMapSizeY = TheRenderManager->height / TheSettingManager->SettingsMain.OcclusionCulling.OcclusionMapRatio;
 #if !DEBUGOC	
-	char* VertexShaderName = "OcclusionMap.vso";
-	char* PixelShaderName = "OcclusionMap.pso";
+	const char* VertexShaderName = "OcclusionMap.vso";
+	const char* PixelShaderName = "OcclusionMap.pso";
 #else
-	char* VertexShaderName = "OcclusionMapDebug.vso";
-	char* PixelShaderName = "OcclusionMapDebug.pso";
+	const char* VertexShaderName = "OcclusionMapDebug.vso";
+	const char* PixelShaderName = "OcclusionMapDebug.pso";
 #endif
 
 	TheOcclusionManager->WaterOccluded = false;

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -1021,7 +1021,7 @@ void ShaderManager::UpdateConstants() {
 	ShaderConst.Water.waterSettings.x = Tes->GetWaterHeight(Player, WorldSceneGraph);
 	ShaderConst.Water.waterSettings.z = isUnderwater;
 
-	float updateDelay = 0.01;
+	float updateDelay = 0.01f;
 
 	if (currentCell) {
 		ShaderConst.SunTiming.x = WorldSky->GetSunriseColorBegin();
@@ -1078,7 +1078,7 @@ void ShaderManager::UpdateConstants() {
 				// moonphase goes from 0 to 8
 				float MoonPhase = (fmod(DaysPassed, 8 * currentClimate->phaseLength & 0x3F)) / (currentClimate->phaseLength & 0x3F);
 
-				float PI = 3.1416; // use cos curve to fade moon light shadows strength
+				float PI = 3.14159f; // use cos curve to fade moon light shadows strength
 				MoonPhase = lerp(-PI, PI, MoonPhase / 8) - PI / 4; // map moonphase to 1/2PI/2PI + 1/2
 
 				// map MoonVisibility to MinNightDarkness/1 range
@@ -1252,7 +1252,7 @@ void ShaderManager::UpdateConstants() {
 			ShaderConst.BloodLens.Percent = 0.0f;
 			ShaderConst.WaterLens.Percent = -1.0f;
 			ShaderConst.Animators.WaterLensAnimator.switched = true;
-			ShaderConst.Animators.WaterLensAnimator.Start(0.0, 0);
+			ShaderConst.Animators.WaterLensAnimator.Start(0.0f, 0);
 		}
 
 		if (Effects.WaterLens->Enabled) {
@@ -1264,7 +1264,7 @@ void ShaderManager::UpdateConstants() {
 				ShaderConst.WaterLens.Time.y = TheSettingManager->GetSettingF("Shaders.WaterLens.Main", "TimeMultB");
 				ShaderConst.WaterLens.Time.z = TheSettingManager->GetSettingF("Shaders.WaterLens.Main", "Viscosity");
 				ShaderConst.Animators.WaterLensAnimator.Initialize(1);
-				ShaderConst.Animators.WaterLensAnimator.Start(0.01, 0);
+				ShaderConst.Animators.WaterLensAnimator.Start(0.01f, 0);
 			}
 			ShaderConst.WaterLens.Percent = ShaderConst.Animators.WaterLensAnimator.GetValue();
 			ShaderConst.WaterLens.Time.w = TheSettingManager->GetSettingF("Shaders.WaterLens.Main", "Amount") * ShaderConst.WaterLens.Percent;
@@ -1277,14 +1277,14 @@ void ShaderManager::UpdateConstants() {
 				ShaderConst.WetWorld.Data.y = 1.0f;
 				ShaderConst.Animators.PuddlesAnimator.Start(TheSettingManager->GetSettingF("Shaders.WetWorld.Main", "Increase"), 1);
 				ShaderConst.Animators.RainAnimator.switched = true;
-				ShaderConst.Animators.RainAnimator.Start(0.05, 1);
+				ShaderConst.Animators.RainAnimator.Start(0.05f, 1);
 			}
 			else if (!isRainy && ShaderConst.Animators.RainAnimator.switched) {
 				// it just stopped raining
 				ShaderConst.WetWorld.Data.y = 0.0f;
 				ShaderConst.Animators.PuddlesAnimator.Start(TheSettingManager->GetSettingF("Shaders.WetWorld.Main", "Decrease"), 0);
 				ShaderConst.Animators.RainAnimator.switched = false;
-				ShaderConst.Animators.RainAnimator.Start(0.07, 0);
+				ShaderConst.Animators.RainAnimator.Start(0.07f, 0);
 			}
 			ShaderConst.WetWorld.Data.x = ShaderConst.Animators.RainAnimator.GetValue();
 			ShaderConst.WetWorld.Data.z = ShaderConst.Animators.PuddlesAnimator.GetValue();
@@ -1309,15 +1309,15 @@ void ShaderManager::UpdateConstants() {
 				// Snow fall
 				if (isSnow && ShaderConst.Animators.SnowAnimator.switched == false) {
 					// it just started snowing
-					ShaderConst.Animators.PuddlesAnimator.Start(0.3, 0); // fade out any puddles if they exist
+					ShaderConst.Animators.PuddlesAnimator.Start(0.3f, 0); // fade out any puddles if they exist
 					ShaderConst.Animators.SnowAnimator.switched = true;
 					ShaderConst.Animators.SnowAnimator.Initialize(0);
-					ShaderConst.Animators.SnowAnimator.Start(0.5, 1);
+					ShaderConst.Animators.SnowAnimator.Start(0.5f, 1);
 				}
 				else if (!isSnow && ShaderConst.Animators.SnowAnimator.switched) {
 					// it just stopped snowing
 					ShaderConst.Animators.SnowAnimator.switched = false;
-					ShaderConst.Animators.SnowAnimator.Start(0.2, 0);
+					ShaderConst.Animators.SnowAnimator.Start(0.2f, 0);
 				}
 				ShaderConst.Snow.SnowData.x = ShaderConst.Animators.SnowAnimator.GetValue();
 

--- a/TESReloaded/Framework/NewVegas/Framework.h
+++ b/TESReloaded/Framework/NewVegas/Framework.h
@@ -2,7 +2,6 @@
 #pragma warning (disable: 4244) //disable warning for possible loss of data in implicit cast between int, float and double
 
 #define DETOURS_INTERNAL
-#define assert(a) static_assert(a, "Assertion failed")
 #define DIRECTINPUT_VERSION 0x0800
 
 #include <windows.h>

--- a/TESReloaded/Framework/NewVegas/Game.h
+++ b/TESReloaded/Framework/NewVegas/Game.h
@@ -69,7 +69,7 @@ class TESLoadScreen;
 class TESEffectShader;
 class TESRegionDataManager;
 class TESPackageData;
-class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; assert(sizeof(TESChildCell) == 0x004);
+class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; static_assert(sizeof(TESChildCell) == 0x004);
 class TESImageSpace;
 class TESImageSpaceModifier;
 class TESReputation;
@@ -174,7 +174,7 @@ public:
 	UInt32		typeID;		// ParamType
 	UInt32		isOptional;
 };
-assert(sizeof(CommandParam) == 0x00C);
+static_assert(sizeof(CommandParam) == 0x00C);
 
 class CommandArgs {
 public:
@@ -187,7 +187,7 @@ public:
 	double*			 result;		// 18
 	UInt32*			 opcodeOffset;	// 1C
 };
-assert(sizeof(CommandArgs) == 0x020);
+static_assert(sizeof(CommandArgs) == 0x020);
 
 class CommandInfo {
 public:
@@ -203,7 +203,7 @@ public:
 	void*			eval;			// 20
 	UInt32			flags;			// 24
 };
-assert(sizeof(CommandInfo) == 0x028);
+static_assert(sizeof(CommandInfo) == 0x028);
 
 template <typename T>
 class TList {
@@ -237,7 +237,7 @@ public:
 
 	Entry First;
 };
-assert(sizeof(TList<void>) == 0x008);
+static_assert(sizeof(TList<void>) == 0x008);
 
 template <typename T>
 class TArray {
@@ -247,7 +247,7 @@ public:
 	UInt32	capacity;	// 08
 	UInt32	count;		// 0C
 };
-assert(sizeof(TArray<void>) == 0x10);
+static_assert(sizeof(TArray<void>) == 0x10);
 
 class RGBA {
 public:
@@ -256,7 +256,7 @@ public:
 	UInt8	b;
 	UInt8	a;
 };
-assert(sizeof(RGBA) == 0x004);
+static_assert(sizeof(RGBA) == 0x004);
 
 class BSString {
 public:
@@ -266,7 +266,7 @@ public:
 	UInt16		m_dataLen;  // 04
 	UInt16		m_bufLen;	// 06
 };
-assert(sizeof(BSString) == 0x008);
+static_assert(sizeof(BSString) == 0x008);
 
 class BSFixedString {
 public:
@@ -275,7 +275,7 @@ public:
 	bool operator == (const BSFixedString& lhs) const { return m_data == lhs.m_data; }
 	bool operator < (const BSFixedString& lhs) const { return m_data < lhs.m_data; }
 };
-assert(sizeof(BSFixedString) == 0x04);
+static_assert(sizeof(BSFixedString) == 0x04);
 
 class BSExtraData {
 public:
@@ -421,7 +421,7 @@ public:
 	UInt8			pad[3];		// 005
 	BSExtraData*	next;		// 008
 };
-assert(sizeof(BSExtraData) == 0x0C);
+static_assert(sizeof(BSExtraData) == 0x0C);
 
 class InventoryChanges : public BSExtraData {
 public:
@@ -442,14 +442,14 @@ public:
 
 	Data*	data;			// 00C
 };
-assert(sizeof(InventoryChanges) == 0x10);
+static_assert(sizeof(InventoryChanges) == 0x10);
 
 class ExtraHavok : public BSExtraData {
 public:
 	bhkRefObject*	world;	// 00C bhkWorld
 	UInt32			unk10;	// 010
 };
-assert(sizeof(ExtraHavok) == 0x014);
+static_assert(sizeof(ExtraHavok) == 0x014);
 
 
 class ExtraRefractionProperty : public BSExtraData
@@ -457,7 +457,7 @@ class ExtraRefractionProperty : public BSExtraData
 public:
 	float		refractionAmount;		// range of 0-1
 };
-assert(sizeof(ExtraRefractionProperty) == 0x010);  //TODO check
+static_assert(sizeof(ExtraRefractionProperty) == 0x010);  //TODO check
 //
 class ExtraDataList {
 public:
@@ -472,7 +472,7 @@ public:
 	UInt8						m_presenceBitfield[0x15];	// 008 - if a bit is set, then the extralist should contain that extradata - bits are numbered starting from the lsb
 	UInt8						pad[3];
 };
-assert(sizeof(ExtraDataList) == 0x20);
+static_assert(sizeof(ExtraDataList) == 0x20);
 
 class MagicCaster {
 public:
@@ -499,7 +499,7 @@ public:
 
 	UInt32	unk04[2];	// 04
 };
-assert(sizeof(MagicCaster) == 0xC);
+static_assert(sizeof(MagicCaster) == 0xC);
 
 class MagicTarget {
 public:
@@ -518,7 +518,7 @@ public:
 
 	UInt32	unk04[3];	// 04
 };
-assert(sizeof(MagicTarget) == 0x10);
+static_assert(sizeof(MagicTarget) == 0x10);
 
 class BaseFormComponent {
 public:
@@ -527,7 +527,7 @@ public:
 	virtual void	CopyFromBase(BaseFormComponent* component);
 	virtual bool	CompareWithBase(BaseFormComponent* src);
 };
-assert(sizeof(BaseFormComponent) == 0x004);
+static_assert(sizeof(BaseFormComponent) == 0x004);
 
 class TESDescription : public BaseFormComponent {
 public:
@@ -535,7 +535,7 @@ public:
 
 	UInt32	formDiskOffset;	// 04
 };
-assert(sizeof(TESDescription) == 0x008);
+static_assert(sizeof(TESDescription) == 0x008);
 
 class TESModel : public BaseFormComponent {
 public:
@@ -556,10 +556,10 @@ public:
 	UInt8		facegenFlags;	// 14
 	UInt8		pad15[3];		// 15
 };
-assert(sizeof(TESModel) == 0x018);
+static_assert(sizeof(TESModel) == 0x018);
 
 class TESModelAnim : public TESModel {};
-assert(sizeof(TESModelAnim) == 0x018);
+static_assert(sizeof(TESModelAnim) == 0x018);
 
 class TESScriptableForm : public BaseFormComponent {
 public:
@@ -567,7 +567,7 @@ public:
 	UInt8	unk1;		// 008
 	UInt8	pad[3];		// 009
 };
-assert(sizeof(TESScriptableForm) == 0x00C);
+static_assert(sizeof(TESScriptableForm) == 0x00C);
 
 class TESEnchantableForm : public BaseFormComponent {
 public:
@@ -576,88 +576,88 @@ public:
 	UInt16			 unk1;			// 0A
 	UInt32			 unk2;			// 0C
 };
-assert(sizeof(TESEnchantableForm) == 0x010);
+static_assert(sizeof(TESEnchantableForm) == 0x010);
 
 class TESValueForm : public BaseFormComponent {
 public:
 	UInt32	value;
 };
-assert(sizeof(TESValueForm) == 0x008);
+static_assert(sizeof(TESValueForm) == 0x008);
 
 class TESWeightForm : public BaseFormComponent {
 public:
 	float	weight;
 };
-assert(sizeof(TESWeightForm) == 0x008);
+static_assert(sizeof(TESWeightForm) == 0x008);
 
 class TESHealthForm : public BaseFormComponent {
 public:
 	UInt32	health;
 };
-assert(sizeof(TESHealthForm) == 0x008);
+static_assert(sizeof(TESHealthForm) == 0x008);
 
 class TESAttackDamageForm : public BaseFormComponent {
 public:
 	UInt16	damage;
 	UInt16	unk0;	// bitmask? perhaps 2 UInt8s?
 };
-assert(sizeof(TESAttackDamageForm) == 0x008);
+static_assert(sizeof(TESAttackDamageForm) == 0x008);
 
 class BGSAmmoForm : public BaseFormComponent {
 public:
 	TESForm* ammo; // 04	either TESAmmo or BGSListForm
 };
-assert(sizeof(BGSAmmoForm) == 0x008);
+static_assert(sizeof(BGSAmmoForm) == 0x008);
 
 class BGSClipRoundsForm : public BaseFormComponent {
 public:
 	UInt8	clipRounds;
 	UInt8	padding[3];
 };
-assert(sizeof(BGSClipRoundsForm) == 0x008);
+static_assert(sizeof(BGSClipRoundsForm) == 0x008);
 
 class BGSDestructibleObjectForm : public BaseFormComponent {
 public:
 	void*	data;			// 04 DestructibleData*
 };
-assert(sizeof(BGSDestructibleObjectForm) == 0x08);
+static_assert(sizeof(BGSDestructibleObjectForm) == 0x08);
 
 class BGSRepairItemList : public BaseFormComponent {
 public:
 	void*	listForm;	// 04 BGSListForm*
 };
-assert(sizeof(BGSRepairItemList) == 0x08);
+static_assert(sizeof(BGSRepairItemList) == 0x08);
 
 class BGSEquipType : public BaseFormComponent {
 public:
 	UInt32	equipType;	// 04
 };
-assert(sizeof(BGSEquipType) == 0x08);
+static_assert(sizeof(BGSEquipType) == 0x08);
 
 class BGSPreloadable : public BaseFormComponent {
 public:
 	virtual void	Fn_04();
 };
-assert(sizeof(BGSPreloadable) == 0x04);
+static_assert(sizeof(BGSPreloadable) == 0x04);
 
 class BGSMessageIcon : public BaseFormComponent {
 public:
 	UInt32	icon[3];		// 004 TESIcon class
 };
-assert(sizeof(BGSMessageIcon) == 0x10);
+static_assert(sizeof(BGSMessageIcon) == 0x10);
 
 class BGSBipedModelList : public BaseFormComponent {
 public:
 	void*	models;		// 004 BGSListForm*
 };
-assert(sizeof(BGSBipedModelList) == 0x08);
+static_assert(sizeof(BGSBipedModelList) == 0x08);
 
 class BGSPickupPutdownSounds : public BaseFormComponent {
 public:
 	TESSound* pickupSound;		// 004
 	TESSound* putdownSound;		// 008
 };
-assert(sizeof(BGSPickupPutdownSounds) == 0x0C);
+static_assert(sizeof(BGSPickupPutdownSounds) == 0x0C);
 
 class TESModelTextureSwap : public TESModel {
 public:
@@ -675,7 +675,7 @@ public:
 
 	TList<Texture>	textureList;	// 018
 };
-assert(sizeof(TESModelTextureSwap) == 0x020);
+static_assert(sizeof(TESModelTextureSwap) == 0x020);
 
 class TESForm : public BaseFormComponent {
 public:
@@ -903,7 +903,7 @@ public:
 	UInt32				refID;					// 00C
 	TList<ModInfo>		modRefList;				// 010
 };
-assert(sizeof(TESForm) == 0x018);
+static_assert(sizeof(TESForm) == 0x018);
 
 class TESPackage : public TESForm {
 public:
@@ -1167,7 +1167,7 @@ public:
 	PackageTime			time;				// 038
 	UInt32				unk040[(0x80 - 0x40) >> 2];		// 040	040 is a tList of Condition, 7C is an Interlocked counter
 };
-assert(sizeof(TESPackage) == 0x80);
+static_assert(sizeof(TESPackage) == 0x80);
 
 class PackageInfo {
 public:
@@ -1178,7 +1178,7 @@ public:
 	float			unk10;			// 10	Initialized to -1.0	. Set to GameHour on start so some time
 	UInt32			flags;			// 14	Flags, bit0 would be not created and initialized
 };
-assert(sizeof(PackageInfo) == 0x18);
+static_assert(sizeof(PackageInfo) == 0x18);
 
 class TESIdleForm : public TESForm {
 public:
@@ -1213,22 +1213,22 @@ public:
 	TESIdleForm*		previous;		// 048
 	BSString			str04C;			// 04C
 };
-assert(sizeof(TESIdleForm) == 0x54);
+static_assert(sizeof(TESIdleForm) == 0x54);
 
 class TESTexture : public BaseFormComponent {
 public:
 	BSString	ddsPath;		// 04
 };
-assert(sizeof(TESTexture) == 0x0C);
+static_assert(sizeof(TESTexture) == 0x0C);
 
 class TESIcon : public TESTexture { };
-assert(sizeof(TESIcon) == 0x0C);
+static_assert(sizeof(TESIcon) == 0x0C);
 
 class TESFullName : public BaseFormComponent {
 public:
 	BSString	name;		// 004
 };
-assert(sizeof(TESFullName) == 0x0C);
+static_assert(sizeof(TESFullName) == 0x0C);
 
 class TESWeather : public TESForm {
 public:
@@ -1331,14 +1331,14 @@ public:
 	float					hdrInfo[14];				// 200 for the compatibility with OR (to review)
 	UInt32					unk238[77];					// 238
 };
-assert(sizeof(TESWeather) == 0x36C);
+static_assert(sizeof(TESWeather) == 0x36C);
 
 class TESWeatherEx : public TESWeather {
 public:
 	ColorData	colorsb[TESWeather::kNumColorTypes];
 	char		EditorName[40];
 };
-assert(sizeof(TESWeatherEx) == 0x484);
+static_assert(sizeof(TESWeatherEx) == 0x484);
 
 class TESClimate : public TESForm {
 public:
@@ -1361,7 +1361,7 @@ public:
 	UInt8				phaseLength;		// 55
 	UInt8				pad56[2];			// 56
 };
-assert(sizeof(TESClimate) == 0x58);
+static_assert(sizeof(TESClimate) == 0x58);
 
 class TESWaterForm : public TESForm {
 public:
@@ -1458,7 +1458,7 @@ public:
 	Properties				properties;		// 084
 	UInt32					unk168[11];		// 168
 };
-assert(sizeof(TESWaterForm) == 0x194);
+static_assert(sizeof(TESWaterForm) == 0x194);
 
 class TESWorldSpace : public TESForm {
 public:
@@ -1598,7 +1598,7 @@ public:
 	TESTexture				waterNoiseTexture;	// 0E0 confirmed XNAM
 
 };
-assert(sizeof(TESWorldSpace) == 0xEC);
+static_assert(sizeof(TESWorldSpace) == 0xEC);
 
 class TESGlobal : public TESForm {
 public:
@@ -1607,7 +1607,7 @@ public:
 	UInt8		pad21[3];	// 021
 	float		data;		// 024
 };
-assert(sizeof(TESGlobal) == 0x028);
+static_assert(sizeof(TESGlobal) == 0x028);
 
 class TESRegion : public TESForm {
 public:
@@ -1617,20 +1617,20 @@ public:
 	TESWeather*		weather;		// 24
 	UInt32			unk28[4];		// 28
 };
-assert(sizeof(TESRegion) == 0x38);
+static_assert(sizeof(TESRegion) == 0x38);
 
 class TESRegionEx : public TESRegion {
 public:
 	char		EditorName[40];		// 38
 };
-assert(sizeof(TESRegionEx) == 0x060);
+static_assert(sizeof(TESRegionEx) == 0x060);
 
 class TESRegionList {
 public:
 	void**			_vtbl;		// 000
 	TList<TESRegion> list;		// 004
 };
-assert(sizeof(TESRegionList) == 0x0C);
+static_assert(sizeof(TESRegionList) == 0x0C);
 
 class TESQuest : public TESForm {
 public:
@@ -1670,7 +1670,7 @@ public:
 	UInt8						pad061[3];				// 061
 	BSString					editorName;				// 064
 };
-assert(sizeof(TESQuest) == 0x6C);
+static_assert(sizeof(TESQuest) == 0x6C);
 
 class TESObject : public TESForm {
 public:
@@ -1691,7 +1691,7 @@ public:
 	virtual UInt32	Unk_5C();
 	virtual bool	Unk_5D(TESObjectREFR* refr);	// if false, no NiNode gets returned by Unk_53, true for NPC
 };
-assert(sizeof(TESObject) == 0x018);
+static_assert(sizeof(TESObject) == 0x018);
 
 class TESBoundObject : public TESObject {
 public:
@@ -1703,17 +1703,17 @@ public:
 	TESBoundObject*			next;		// 020
 	SInt16					bounds[6];	// 024
 };
-assert(sizeof(TESBoundObject) == 0x030);
+static_assert(sizeof(TESBoundObject) == 0x030);
 
 class TESBoundAnimObject : public TESBoundObject {};
-assert(sizeof(TESBoundAnimObject) == 0x30);
+static_assert(sizeof(TESBoundAnimObject) == 0x30);
 
 class TESSoundFile : public BaseFormComponent {
 public:
 	virtual void	Set(const char* str);
 	BSString		fileName;	// 04
 };
-assert(sizeof(TESSoundFile) == 0x0C);
+static_assert(sizeof(TESSoundFile) == 0x0C);
 
 class TESSound : public TESBoundAnimObject {
 public:
@@ -1754,14 +1754,14 @@ public:
 	UInt32			unk60;					// 60
 	UInt32			unk64;					// 64
 };
-assert(sizeof(TESSound) == 0x68);
+static_assert(sizeof(TESSound) == 0x68);
 
 class TESObjectSTAT : public TESBoundObject {
 public:
 	TESModelTextureSwap		model;		// 30
 	UInt32					unk50[2];	// 50
 };
-assert(sizeof(TESObjectSTAT) == 0x058);
+static_assert(sizeof(TESObjectSTAT) == 0x058);
 
 class TESObjectIMOD : public TESBoundObject {
 public:
@@ -1776,7 +1776,7 @@ public:
 	BGSMessageIcon				messageIcon;		// 094
 	BGSPickupPutdownSounds		pickupPutdownSounds;// 0A4
 };
-assert(sizeof(TESObjectIMOD) == 0x0B0);
+static_assert(sizeof(TESObjectIMOD) == 0x0B0);
 
 class TESObjectLIGH : public TESBoundAnimObject {
 public:
@@ -1814,7 +1814,7 @@ public:
 	TESSound					*sound;			// 0B8
 	UInt32						padBC[3];		// 0BC
 };
-assert(sizeof(TESObjectLIGH) == 0x0C8);
+static_assert(sizeof(TESObjectLIGH) == 0x0C8);
 
 class TESObjectWEAP : public TESBoundObject {
 public:
@@ -2094,7 +2094,7 @@ public:
 	UInt32				recharge;			// 380 maybe recharge
 	UInt32				unk384;				// 384
 };
-assert(sizeof(TESObjectWEAP) == 0x388);
+static_assert(sizeof(TESObjectWEAP) == 0x388);
 
 class BGSPerkEntry {
 public:
@@ -2117,7 +2117,7 @@ public:
 	UInt8				priority;			// 05
 	UInt16				type;				// 06 (Quest: 0xC24, Ability: 0xB27, Entry Point: 0xD16)
 };
-assert(sizeof(BGSPerkEntry) == 0x08);
+static_assert(sizeof(BGSPerkEntry) == 0x08);
 
 class BGSPerk : public TESForm {
 public:
@@ -2139,7 +2139,7 @@ public:
 	TList<void*>			conditions;			// 40 Condition List
 	TList<BGSPerkEntry>		entries;			// 48
 };
-assert(sizeof(BGSPerk) == 0x50);
+static_assert(sizeof(BGSPerk) == 0x50);
 
 class TESObjectREFRData {
 public:
@@ -2151,7 +2151,7 @@ public:
 	NiNode* niNode;
 	// possibly more, need to find alloc
 };
-assert(sizeof(TESObjectREFRData) == 0x18);
+static_assert(sizeof(TESObjectREFRData) == 0x18);
 
 class TESObjectCELL : public TESForm {
 public:
@@ -2232,7 +2232,7 @@ public:
 	BGSLightingTemplate*	lightingTemplate;	// 0D8
 	UInt32					unk0DC;				// 0DC
 };
-assert(sizeof(TESObjectCELL) == 0xE0);
+static_assert(sizeof(TESObjectCELL) == 0xE0);
 
 struct ActorHitInfo {
 	TESObjectREFR*		source;			// 00
@@ -2254,7 +2254,7 @@ struct ActorHitInfo {
 	float				unk5C;			// 5C
 	UInt32				unk60;			// 60
 };
-assert(sizeof(ActorHitInfo) == 0x064);
+static_assert(sizeof(ActorHitInfo) == 0x064);
 
 class BaseProcess {
 public:
@@ -2770,7 +2770,7 @@ public:
 	UInt32			processLevel;	// 28	not initialized, only by descendant to 3 for Low, 2 for MidlleLow, 1 MiddleHighProcess and 0 for HigProcess
 	Data2C*			unk2C;			// 2C
 };
-assert(sizeof(BaseProcess) == 0x030);
+static_assert(sizeof(BaseProcess) == 0x030);
 
 class LowProcess : public BaseProcess {
 public:
@@ -2846,7 +2846,7 @@ public:
 	UInt32				unkAC;		// not initialized!
 	UInt32				unkB0;		// not initialized!
 };
-assert(sizeof(LowProcess) == 0x0B4);
+static_assert(sizeof(LowProcess) == 0x0B4);
 
 class MiddleLowProcess : public LowProcess {
 public:
@@ -2855,7 +2855,7 @@ public:
 	UInt32				unk0B4;			// B4
 	ActorValueModifiers	tempModifiers;	// B8
 };
-assert(sizeof(MiddleLowProcess) == 0x0C8);
+static_assert(sizeof(MiddleLowProcess) == 0x0C8);
 
 class MiddleHighProcess : public MiddleLowProcess {
 public:
@@ -2938,7 +2938,7 @@ public:
 	ActorHitInfo*						hitInfo254;			// 254
 	UInt32								unk258;				// 258
 };
-assert(sizeof(MiddleHighProcess) == 0x25C);
+static_assert(sizeof(MiddleHighProcess) == 0x25C);
 
 class HighProcess : public MiddleHighProcess {
 public:
@@ -3017,7 +3017,7 @@ public:
 	UInt8						pad445[3];			// 445
 	UInt32						unk448[9];			// 448
 };
-assert(sizeof(HighProcess) == 0x46C);
+static_assert(sizeof(HighProcess) == 0x46C);
 
 class HighProcessEx : public HighProcess {
 public:
@@ -3046,7 +3046,7 @@ public:
 	UInt8							OnBeltActionState;
 	UInt8							OnBeltState;
 };
-assert(sizeof(HighProcessEx) == 0x480);
+static_assert(sizeof(HighProcessEx) == 0x480);
 
 class TESObjectREFR : public TESForm {
 public:
@@ -3139,7 +3139,7 @@ public:
 	ExtraDataList		extraDataList;			// 044
 	TESObjectREFRData*	renderData;				// 064	- (05C in FOSE)
 };
-assert(sizeof(TESObjectREFR) == 0x068);
+static_assert(sizeof(TESObjectREFR) == 0x068);
 
 class MobileObject : public TESObjectREFR {
 public:
@@ -3211,7 +3211,7 @@ public:
 	UInt8			unk086;			// 086 - loaded
 	UInt8			unk087;			// 087	Init'd to the inverse of NoLowLevelProcessing
 };
-assert(sizeof(MobileObject) == 0x088);
+static_assert(sizeof(MobileObject) == 0x088);
 
 class ActorValuesOwner {
 public:
@@ -3227,7 +3227,7 @@ public:
 	virtual void*	Fn_09();								// GetActorBase (= this - 0x100) or GetActorBase (= this - 0x0A4)
 	virtual UInt16	GetLevel();								// GetLevel (from ActorBase)
 };
-assert(sizeof(ActorValuesOwner) == 0x004);
+static_assert(sizeof(ActorValuesOwner) == 0x004);
 
 class CachedValuesOwner {
 public:
@@ -3248,7 +3248,7 @@ public:
 	virtual float	Fn_0E();
 	virtual bool	Fn_0F();
 };
-assert(sizeof(CachedValuesOwner) == 0x004);
+static_assert(sizeof(CachedValuesOwner) == 0x004);
 
 class PathingLocation {
 public:
@@ -3258,7 +3258,7 @@ public:
 
 	UInt32			unk04[9];	// 04
 };
-assert(sizeof(PathingLocation) == 0x028);
+static_assert(sizeof(PathingLocation) == 0x028);
 
 class ActorMover {
 public:
@@ -3306,7 +3306,7 @@ public:
 	UInt32				unk80;				// 80
 	UInt32				unk84;				// 84
 };
-assert(sizeof(ActorMover) == 0x088);
+static_assert(sizeof(ActorMover) == 0x088);
 
 class Actor : public MobileObject {
 public:
@@ -3630,7 +3630,7 @@ public:
 	UInt8				byte1B2;					// 1B2
 	UInt8				byte1B3;					// 1B3
 };
-assert(sizeof(Actor) == 0x1B4);
+static_assert(sizeof(Actor) == 0x1B4);
 
 class Creature : public Actor {
 public:
@@ -3638,7 +3638,7 @@ public:
 
 	UInt32			unk1B4[3];			// 1B4
 };
-assert(sizeof(Creature) == 0x1C0);
+static_assert(sizeof(Creature) == 0x1C0);
 
 class Character : public Actor {
 public:
@@ -3653,7 +3653,7 @@ public:
 	UInt16			unk1C2;				// 1C2
 	float			unk1C4;				// 1C4
 };
-assert(sizeof(Character) == 0x1C8);
+static_assert(sizeof(Character) == 0x1C8);
 
 class PlayerCharacter : public Character {
 public:
@@ -3761,7 +3761,7 @@ public:
 	UInt8				byteDF3;				// DF3
 	UInt32				unkDF4[23];				// DF4
 };
-assert(sizeof(PlayerCharacter) == 0xE50);
+static_assert(sizeof(PlayerCharacter) == 0xE50);
 
 class SkinInfo {
 public:
@@ -3805,7 +3805,7 @@ public:
 	NiNode*			LightObject;			// 094 PipBoyObject (LightObject to maintain the compatibility with OR)
 	UInt32			unk098[135];
 };
-assert(sizeof(SkinInfo) == 0x2B4);
+static_assert(sizeof(SkinInfo) == 0x2B4);
 
 class AnimSequenceBase {
 public:
@@ -3817,19 +3817,19 @@ public:
 	virtual BSAnimGroupSequence*	GetAnimGroupSequence2(void* Unk01);
 	virtual void					Unk_06();
 };
-assert(sizeof(AnimSequenceBase) == 0x004);
+static_assert(sizeof(AnimSequenceBase) == 0x004);
 
 class AnimSequenceSingle : public AnimSequenceBase {
 public:
 	BSAnimGroupSequence* Anim;	// 04
 };
-assert(sizeof(AnimSequenceSingle) == 0x008);
+static_assert(sizeof(AnimSequenceSingle) == 0x008);
 
 class AnimSequenceMultiple : public AnimSequenceBase {
 public:
 	NiTList<BSAnimGroupSequence>* Anims;	// 04
 };
-assert(sizeof(AnimSequenceMultiple) == 0x008);
+static_assert(sizeof(AnimSequenceMultiple) == 0x008);
 
 class ActorAnimData {
 public:
@@ -3868,7 +3868,7 @@ public:
 	void*						unk124;				// 124
 	void*						unk128;				// 128
 };
-assert(sizeof(ActorAnimData) == 0x12C);
+static_assert(sizeof(ActorAnimData) == 0x12C);
 
 class TESAnimGroup : public NiRefObject {
 public:
@@ -3927,7 +3927,7 @@ public:
 	UInt8		pad013;			//013
 	UInt32		unk014[10];		//014
 };
-assert(sizeof(TESAnimGroup) == 0x03C);
+static_assert(sizeof(TESAnimGroup) == 0x03C);
 
 class SkyObject {
 public:
@@ -3938,7 +3938,7 @@ public:
 
 	NiNode*				RootNode;	// 04
 };
-assert(sizeof(SkyObject) == 0x08);
+static_assert(sizeof(SkyObject) == 0x08);
 
 class Sun : public SkyObject {
 public:
@@ -3955,7 +3955,7 @@ public:
 	UInt8				 byte27;			// 27
 	BSShaderAccumulator* shaderAccum;		// 28 BSShaderAccumulator*
 };
-assert(sizeof(Sun) == 0x2C);
+static_assert(sizeof(Sun) == 0x2C);
 
 class Atmosphere : public SkyObject {
 public:
@@ -3969,7 +3969,7 @@ public:
 	UInt8			pad19[3];
 
 };
-assert(sizeof(Atmosphere) == 0x01C);
+static_assert(sizeof(Atmosphere) == 0x01C);
 
 class NiFogProperty : public NiProperty
 {
@@ -3992,7 +3992,7 @@ public:
 	NiColor kWaterColor;
 	float fPower;
 };
-assert(sizeof(BSFogProperty) == 0x64);
+static_assert(sizeof(BSFogProperty) == 0x64);
 
 
 class Stars : public SkyObject {	
@@ -4000,7 +4000,7 @@ public:
 	NiNode*			node08;			// 08
 	float			flt0C;			// 0C
 };
-assert(sizeof(Stars) == 0x010);
+static_assert(sizeof(Stars) == 0x010);
 
 class Clouds : public SkyObject {
 public:
@@ -4012,7 +4012,7 @@ public:
 	UInt8				byte5A;			// 5A
 	UInt8				byte5B;			// 5B
 };
-assert(sizeof(Clouds) == 0x05C);
+static_assert(sizeof(Clouds) == 0x05C);
 
 class Precipitation {
 public:
@@ -4024,7 +4024,7 @@ public:
 	float		unk10;		// 10
 	UInt32		unk14;		// 14
 };
-assert(sizeof(Precipitation) == 0x018);
+static_assert(sizeof(Precipitation) == 0x018);
 
 class Moon : public SkyObject {
 public:
@@ -4076,7 +4076,7 @@ public:
         return 0;
     }
 };
-assert(sizeof(Moon) == 0x07C);
+static_assert(sizeof(Moon) == 0x07C);
 
 class Sky {
 public:
@@ -4171,7 +4171,7 @@ public:
 	bool GetIsUnderWater() { return this->flags & Sky::kSkyFlag_IsUnderwater; }
 
 };
-assert(sizeof(Sky) == 0x138);
+static_assert(sizeof(Sky) == 0x138);
 
 class GridArray {
 public:
@@ -4182,7 +4182,7 @@ public:
 	virtual void	Fn_04(void);
 	virtual void	Fn_05(void);
 };
-assert(sizeof(GridArray) == 0x04);
+static_assert(sizeof(GridArray) == 0x04);
 
 class GridCellArray : public GridArray {
 public:
@@ -4203,7 +4203,7 @@ public:
 	float			posY;			// 18	worldY * 4096
 	UInt32			unk1C[3];		// 1C
 };
-assert(sizeof(GridCellArray) == 0x028);
+static_assert(sizeof(GridCellArray) == 0x028);
 
 template <typename Data> class DNode{
 public:
@@ -4217,7 +4217,7 @@ public:
     DNode<Data>* last;
     UInt32 count;  
 };
-assert(sizeof(DList<void>) == 0xC);
+static_assert(sizeof(DList<void>) == 0xC);
 
 struct WaterGroup
 {
@@ -4280,7 +4280,7 @@ public:
 	UInt8				unk9C;					// 09C
 	UInt8				pad9C[3];
 };
-assert(sizeof(WaterManager) == 0x0A0);
+static_assert(sizeof(WaterManager) == 0x0A0);
 
 class TES {
 public:
@@ -4393,7 +4393,7 @@ public:
 	void*								navMeshInfoMap;		// BC NavMeshInfoMap*
 	void*								unkC0;				// C0 LoadedAreaBound*
 };
-assert(sizeof(TES) == 0xC4);
+static_assert(sizeof(TES) == 0xC4);
 
 class TESGameSound {
 public:
@@ -4413,13 +4413,13 @@ public:
 	UInt32			unk50;		// 50
 	UInt32			unk54;		// 54
 };
-assert(sizeof(TESGameSound) == 0x058);
+static_assert(sizeof(TESGameSound) == 0x058);
 
 class BSAnimGroupSequence : public NiControllerSequence {
 public:
 	TESAnimGroup* animGroup;	//074
 };
-assert(sizeof(BSAnimGroupSequence) == 0x078);
+static_assert(sizeof(BSAnimGroupSequence) == 0x078);
 
 class Tile {
 public:
@@ -4569,7 +4569,7 @@ public:
 	UInt8						unk35;			// 35
 	UInt8						pad35[2];		// 36
 };
-assert(sizeof(Tile) == 0x38);
+static_assert(sizeof(Tile) == 0x38);
 
 class TileImage : public Tile {
 public:
@@ -4579,19 +4579,19 @@ public:
 	UInt8		byt044;			// 44
 	UInt8		pad044[3];		// 45-47
 };
-assert(sizeof(TileImage) == 0x48);
+static_assert(sizeof(TileImage) == 0x48);
 
 class TileRect : public Tile {
 public:
 	UInt32	unk38;	// 38
 };
-assert(sizeof(TileRect) == 0x3C);
+static_assert(sizeof(TileRect) == 0x3C);
 
 class TileMenu : public TileRect {
 public:
 	Menu*	menu;	// 3C
 };
-assert(sizeof(TileMenu) == 0x40);
+static_assert(sizeof(TileMenu) == 0x40);
 
 class Menu {
 public:
@@ -4673,7 +4673,7 @@ public:
 	UInt32			id;			// 20
 	UInt32			unk24;		// 24
 };
-assert(sizeof(Menu) == 0x28);
+static_assert(sizeof(Menu) == 0x28);
 
 class HUDMainMenu : public Menu {
 public:
@@ -4796,7 +4796,7 @@ public:
 	void*					ptr234;			// 234
 	UInt32					unk238[16];		// 238
 };
-assert(sizeof(HUDMainMenu) == 0x278);
+static_assert(sizeof(HUDMainMenu) == 0x278);
 
 class ModInfo {
 public:
@@ -4887,7 +4887,7 @@ public:
 	UInt8				unk428;				// 428 decide if forms needs to be reloaded on LoadFiles
 	UInt8				pad429[3];
 };
-assert(sizeof(ModInfo) == 0x42C);
+static_assert(sizeof(ModInfo) == 0x42C);
 
 class ModList {
 public:
@@ -4895,7 +4895,7 @@ public:
 	UInt32				loadedModCount;		// 08
 	ModInfo*			loadedMods[0xFF];	// 0C
 };
-assert(sizeof(ModList) == 0x408);
+static_assert(sizeof(ModList) == 0x408);
 
 class MainDataHandler {
 public:
@@ -5009,7 +5009,7 @@ public:
 	UInt32							unk634;					// 634
 	UInt32							unk638;					// 638
 };
-assert(sizeof(MainDataHandler) == 0x63C);
+static_assert(sizeof(MainDataHandler) == 0x63C);
 
 class InputControl {
 public:
@@ -5072,7 +5072,7 @@ public:
 	UInt8					JoystickInputControls[28];			// 1BCC
 	UInt32					unk1BE4[(0x1C00 - 0x1BE4) >> 2];	// 1BE4
 };
-assert(sizeof(InputControl) == 0x1C04);
+static_assert(sizeof(InputControl) == 0x1C04);
 
 class BSAudioManager {
 public:
@@ -5124,7 +5124,7 @@ public:
 	UInt8						byte186;
 	UInt8						byte187;
 };
-assert(sizeof(BSAudioManager) == 0x188);
+static_assert(sizeof(BSAudioManager) == 0x188);
 
 class SoundControl { // BSWin32Audio
 public:
@@ -5150,7 +5150,7 @@ public:
 	DSCAPS					soundCaps;					// 040
 	UInt32					unkA0;						// 0A0
 };
-assert(sizeof(SoundControl) == 0x0A4);
+static_assert(sizeof(SoundControl) == 0x0A4);
 
 class Main {
 public:
@@ -5205,7 +5205,7 @@ public:
 	UInt32			unk9C;				// 9C
 	NiCamera*		camera;				// A0
 };
-assert(sizeof(Main) == 0x0A4);
+static_assert(sizeof(Main) == 0x0A4);
 
 class MenuInterfaceManager {
 public:
@@ -5294,7 +5294,7 @@ public:
 
 	UInt8					getIsMenuOpen() { return pipBoyMode == 3; };
 };
-assert(sizeof(MenuInterfaceManager) == 0x580);
+static_assert(sizeof(MenuInterfaceManager) == 0x580);
 
 class TimeGlobals {
 public:
@@ -5308,13 +5308,13 @@ public:
 	static float GetGameTime() { TimeGlobals* Globals = (TimeGlobals*)0x011DE7B8; return Globals->GameHour->data * 60.0f * 60.0f; }
 	static TimeGlobals* Get() { return (TimeGlobals*)0x11DE7B8; }
 };
-assert(sizeof(TimeGlobals) == 0x018); // Static class, size could be larger
+static_assert(sizeof(TimeGlobals) == 0x018); // Static class, size could be larger
 
 class QueuedModelLoader {
 public:
 	UInt32	Unk000[7]; // LockFreeMaps for models
 };
-assert(sizeof(QueuedModelLoader) == 0x01C);
+static_assert(sizeof(QueuedModelLoader) == 0x01C);
 
 class GameSetting {
 public:
@@ -5326,7 +5326,7 @@ public:
 	};
 	char*		Name;
 };
-assert(sizeof(GameSetting) == 0x0C);
+static_assert(sizeof(GameSetting) == 0x0C);
 
 struct MuzzleFlash
 {

--- a/TESReloaded/Framework/NewVegas/GameHavok.h
+++ b/TESReloaded/Framework/NewVegas/GameHavok.h
@@ -16,26 +16,26 @@ public:
 	float	z;
 	float	w;
 };
-assert(sizeof(hkVector4) == 0x010);
+static_assert(sizeof(hkVector4) == 0x010);
 
 class hkQuaternion {
 public:
 	hkVector4	vec;
 };
-assert(sizeof(hkQuaternion) == 0x010);
+static_assert(sizeof(hkQuaternion) == 0x010);
 
 class hkBaseObject {
 public:
 	virtual void Destructor(bool FreeThis);
 };
-assert(sizeof(hkBaseObject) == 0x004);
+static_assert(sizeof(hkBaseObject) == 0x004);
 
 class hkRefObject : public hkBaseObject {
 public:
 	UInt16		sizeAndFlags;	// 04
 	UInt16		refCount;		// 06
 };
-assert(sizeof(hkRefObject) == 0x008);
+static_assert(sizeof(hkRefObject) == 0x008);
 
 class bhkRefObject : public NiObject {
 public:
@@ -44,7 +44,7 @@ public:
 
 	hkRefObject*	hkObject;	// 008
 };
-assert(sizeof(bhkRefObject) == 0x00C);
+static_assert(sizeof(bhkRefObject) == 0x00C);
 
 class bhkSerializable : public bhkRefObject {
 public:
@@ -62,7 +62,7 @@ public:
 
 	void*			hkData;		// 00C
 };
-assert(sizeof(bhkSerializable) == 0x010);
+static_assert(sizeof(bhkSerializable) == 0x010);
 
 class bhkWorldObject : public bhkSerializable {
 public:
@@ -70,7 +70,7 @@ public:
 	virtual void	Unk_21();
 	virtual NiNode*	CreateNiGeometry(NiNode* Node);
 };
-assert(sizeof(bhkWorldObject) == 0x010);
+static_assert(sizeof(bhkWorldObject) == 0x010);
 
 class bhkRigidBody : public bhkWorldObject {
 public:
@@ -78,7 +78,7 @@ public:
 	UInt32			unk014;		// 014
 	UInt32			unk018;		// 018
 };
-assert(sizeof(bhkRigidBody) == 0x1C);
+static_assert(sizeof(bhkRigidBody) == 0x1C);
 
 class bhkRigidBodyT : public bhkRigidBody {
 public:
@@ -90,7 +90,7 @@ public:
 	UInt32			unk048;		// 048
 	UInt32			unk04C;		// 04C
 };
-assert(sizeof(bhkRigidBodyT) == 0x50);
+static_assert(sizeof(bhkRigidBodyT) == 0x50);
 
 class bhkShape : public bhkSerializable {
 public:
@@ -139,16 +139,16 @@ public:
 
 	UInt32			material;	// 010
 };
-assert(sizeof(bhkShape) == 0x14);
+static_assert(sizeof(bhkShape) == 0x14);
 
 class bhkPackedNiTriStripsShape : public bhkShape {};
-assert(sizeof(bhkPackedNiTriStripsShape) == 0x14);
+static_assert(sizeof(bhkPackedNiTriStripsShape) == 0x14);
 
 class NiCollisionObject : public NiObject {
 public:
 	NiAVObject*		SceneObject;	// 008
 };
-assert(sizeof(NiCollisionObject) == 0x0C);
+static_assert(sizeof(NiCollisionObject) == 0x0C);
 
 class bhkCollisionObject : public NiCollisionObject {
 public:
@@ -163,13 +163,13 @@ public:
 	UInt8				pad00E[2];		// 00E
 	bhkRigidBody*		bRigidBody;		// 010
 };
-assert(sizeof(bhkCollisionObject) == 0x14);
+static_assert(sizeof(bhkCollisionObject) == 0x14);
 
 class bhkCollisionObjectEx : public bhkCollisionObject {
 public:
 	NiNode*			GeoNode;	// 014
 };
-assert(sizeof(bhkCollisionObjectEx) == 0x18);
+static_assert(sizeof(bhkCollisionObjectEx) == 0x18);
 
 class hkWorldRayCastInput {
 public:
@@ -180,7 +180,7 @@ public:
 	UInt32		FilterInfo;						// 24
 	UInt32		pad28[2];
 };
-assert(sizeof(hkWorldRayCastInput) == 0x30);
+static_assert(sizeof(hkWorldRayCastInput) == 0x30);
 
 class hkShapeRayCastOutput {
 public:
@@ -189,14 +189,14 @@ public:
 	float		HitFraction;			// 14
 	UInt32		pad18[2];
 };
-assert(sizeof(hkShapeRayCastOutput) == 0x20);
+static_assert(sizeof(hkShapeRayCastOutput) == 0x20);
 
 class hkWorldRayCastOutput : public hkShapeRayCastOutput {
 public:
 	hkCollidable*	RootCollidable;		// 20
 	UInt32			pad24[3];
 };
-assert(sizeof(hkWorldRayCastOutput) == 0x30);
+static_assert(sizeof(hkWorldRayCastOutput) == 0x30);
 
 class bhkWorldRayCastData {
 public:
@@ -211,7 +211,7 @@ public:
 	hkRayHitCollector*		RayHitCollector2;		// 78
 	UInt32					pad7C;
 };
-assert(sizeof(bhkWorldRayCastData) == 0x80);
+static_assert(sizeof(bhkWorldRayCastData) == 0x80);
 
 class hkWorld : public hkRefObject {
 public:
@@ -220,26 +220,26 @@ public:
 	hkVector4	gravity;				// 020
 	// More...
 };
-assert(sizeof(hkWorld) == 0x020);
+static_assert(sizeof(hkWorld) == 0x020);
 
 class hkShape : public hkRefObject {
 public:
 	bhkRefObject*		bRefObject;		// 008
 };
-assert(sizeof(hkShape) == 0x00C);
+static_assert(sizeof(hkShape) == 0x00C);
 
 class hkPackedNiTriStripsShape : public hkShape {
 public:
 	UInt32						unk0C;					// 00C
 	hkPackedNiTriStripsData*	PackedNiTriStripsData;	// 010
 };
-assert(sizeof(hkPackedNiTriStripsShape) == 0x14);
+static_assert(sizeof(hkPackedNiTriStripsShape) == 0x14);
 
 class hkScaledMoppBvTreeShape : public hkShape {
 public:
 	hkPackedNiTriStripsShape*	PackedNiTriStripsShape;		// 00C
 };
-assert(sizeof(hkScaledMoppBvTreeShape) == 0x010);
+static_assert(sizeof(hkScaledMoppBvTreeShape) == 0x010);
 
 class hkRigidBody : public hkRefObject {
 public:
@@ -281,4 +281,4 @@ public:
 	UInt16				unk08E;			// 08E
 	UInt32				unk090;
 };
-assert(sizeof(hkRigidBody) == 0x94);
+static_assert(sizeof(hkRigidBody) == 0x94);

--- a/TESReloaded/Framework/NewVegas/GameNi.h
+++ b/TESReloaded/Framework/NewVegas/GameNi.h
@@ -65,14 +65,14 @@ struct NiRTTI {
 	const char* name;
 	NiRTTI*		parent;
 };
-assert(sizeof(NiRTTI) == 0x008);
+static_assert(sizeof(NiRTTI) == 0x008);
 
 class NiPoint2 {
 public:
 	float	x;
 	float	y;
 };
-assert(sizeof(NiPoint2) == 0x008);
+static_assert(sizeof(NiPoint2) == 0x008);
 
 class NiPoint3 {
 public:
@@ -88,7 +88,7 @@ public:
 		return D3DXVECTOR4(x, y, z, 1.0);
 	}
 };
-assert(sizeof(NiPoint3) == 0x00C);
+static_assert(sizeof(NiPoint3) == 0x00C);
 
 class NiVector4 {
 public:
@@ -99,7 +99,7 @@ public:
 	float z;
 	float w;
 };
-assert(sizeof(NiVector4) == 0x010);
+static_assert(sizeof(NiVector4) == 0x010);
 
 class NiMatrix33 {
 public:
@@ -155,7 +155,7 @@ public:
 
 	float data[3][3];
 };
-assert(sizeof(NiMatrix33) == 0x024);
+static_assert(sizeof(NiMatrix33) == 0x024);
 
 class NiTransform {
 public:
@@ -163,7 +163,7 @@ public:
 	NiPoint3	pos;		// 24
 	float		scale;		// 30
 };
-assert(sizeof(NiTransform) == 0x034);
+static_assert(sizeof(NiTransform) == 0x034);
 
 class NiPlane {
 public:
@@ -176,7 +176,7 @@ public:
 	NiPoint3	Normal;
 	float		Constant;
 };
-assert(sizeof(NiPlane) == 0x010);
+static_assert(sizeof(NiPlane) == 0x010);
 
 class NiBound {
 public:
@@ -185,7 +185,7 @@ public:
 	NiPoint3	Center;
 	float		Radius;
 };
-assert(sizeof(NiBound) == 0x010);
+static_assert(sizeof(NiBound) == 0x010);
 
 class NiFrustum {
 public:
@@ -198,7 +198,7 @@ public:
 	UInt8	Ortho;		// 18
 	UInt8	pad18[3];
 };
-assert(sizeof(NiFrustum) == 0x01C);
+static_assert(sizeof(NiFrustum) == 0x01C);
 
 class NiFrustumPlanes {
 public:
@@ -215,7 +215,7 @@ public:
 	NiPlane	CullingPlanes[MaxPlanes];	// 00
 	UInt32	ActivePlanes;				// 60
 };
-assert(sizeof(NiFrustumPlanes) == 0x064);
+static_assert(sizeof(NiFrustumPlanes) == 0x064);
 
 class NiViewport {
 public:
@@ -224,7 +224,7 @@ public:
 	float	t;
 	float	b;
 };
-assert(sizeof(NiViewport) == 0x010);
+static_assert(sizeof(NiViewport) == 0x010);
 
 class NiColor {
 public:
@@ -232,7 +232,7 @@ public:
 	float	g;
 	float	b;
 };
-assert(sizeof(NiColor) == 0x00C);
+static_assert(sizeof(NiColor) == 0x00C);
 
 class NiColorAlpha {
 public:
@@ -241,7 +241,7 @@ public:
 	float	b;
 	float	a;
 };
-assert(sizeof(NiColorAlpha) == 0x010);
+static_assert(sizeof(NiColorAlpha) == 0x010);
 
 template <typename T>
 class NiTList {
@@ -256,7 +256,7 @@ public:
 	Entry*	end;		// 004
 	UInt32	numItems;	// 008
 };
-assert(sizeof(NiTList<void>) == 0x00C);
+static_assert(sizeof(NiTList<void>) == 0x00C);
 
 template <typename TKey, typename TData>
 class NiTMap {
@@ -278,7 +278,7 @@ public:
 	Entry**			m_buckets;		// 8
 	UInt32			m_numItems;		// C
 };
-assert(sizeof(NiTMap<void, void>) == 0x010);
+static_assert(sizeof(NiTMap<void, void>) == 0x010);
 
 template <typename T>
 class NiTArray {
@@ -292,7 +292,7 @@ public:
 	UInt16	numObjs;		// 0C - init'd to 0
 	UInt16	growSize;		// 0E - init'd to size of preallocation
 };
-assert(sizeof(NiTArray<void>) == 0x010);
+static_assert(sizeof(NiTArray<void>) == 0x010);
 
 class NiPixelFormat {
 public:
@@ -375,7 +375,7 @@ public:
 	UInt32			ExtraData;		// 10
 	NiComponentSpec	Components[4];	// 14
 };
-assert(sizeof(NiPixelFormat) == 0x044);
+static_assert(sizeof(NiPixelFormat) == 0x044);
 
 class NiRefObject {
 public:
@@ -384,7 +384,7 @@ public:
 
 	UInt32				m_uiRefCount;	// 004
 };
-assert(sizeof(NiRefObject) == 0x008);
+static_assert(sizeof(NiRefObject) == 0x008);
 
 class NiObject : public NiRefObject {
 public:
@@ -425,7 +425,7 @@ public:
     
     void LogObjectAttributes();
 };
-assert(sizeof(NiObject) == 0x008);
+static_assert(sizeof(NiObject) == 0x008);
 
 class NiExtraData : public NiObject {
 public:
@@ -434,7 +434,7 @@ public:
 
 	char*	m_pcName;	// 08
 };
-assert(sizeof(NiExtraData) == 0x00C);
+static_assert(sizeof(NiExtraData) == 0x00C);
 
 class NiObjectNET : public NiObject {
 public:
@@ -446,7 +446,7 @@ public:
 	UInt16				m_extraDataListLen;				// 014
 	UInt16				m_extraDataListCapacity;		// 016
 };
-assert(sizeof(NiObjectNET) == 0x018);
+static_assert(sizeof(NiObjectNET) == 0x018);
 
 struct PropertyNode{
     PropertyNode* next;
@@ -509,7 +509,7 @@ public:
 	NiTransform				m_localTransform;		// 034
 	NiTransform				m_worldTransform;		// 068
 };
-assert(sizeof(NiAVObject) == 0x9C);
+static_assert(sizeof(NiAVObject) == 0x9C);
 
 class NiNode : public NiAVObject {
 public:
@@ -528,7 +528,7 @@ public:
 
 	NiTArray<NiAVObject*>	m_children;	// 09C
 };
-assert(sizeof(NiNode) == 0xAC);
+static_assert(sizeof(NiNode) == 0xAC);
 
 class NiBillboardNode : public NiNode {
 public:
@@ -536,7 +536,7 @@ public:
 
 	UInt32			unkAC[2];		// AC
 };
-assert(sizeof(NiBillboardNode) == 0xB4);
+static_assert(sizeof(NiBillboardNode) == 0xB4);
 
 class NiCamera : public NiAVObject {
 public:
@@ -547,7 +547,7 @@ public:
 	NiViewport		ViewPort;			// 100
 	float			LODAdjust;			// 110
 };
-assert(sizeof(NiCamera) == 0x114);
+static_assert(sizeof(NiCamera) == 0x114);
 
 class SceneGraph : public NiNode {
 public:
@@ -561,7 +561,7 @@ public:
 	UInt8				padB8[3];
 	float				cameraFOV;				// BC
 };
-assert(sizeof(SceneGraph) == 0xC0);
+static_assert(sizeof(SceneGraph) == 0xC0);
 
 class NiDynamicEffect : public NiAVObject {
 public:
@@ -579,7 +579,7 @@ public:
 	UInt32			unkBC;			// BC
 	UInt32			unkC0;			// C0
 };
-assert(sizeof(NiDynamicEffect) == 0xC4);
+static_assert(sizeof(NiDynamicEffect) == 0xC4);
 
 class NiLight : public NiDynamicEffect {
 public:
@@ -589,7 +589,7 @@ public:
 	NiColor			Spec;	// E0
 	void*			unk104;	// EC
 };
-assert(sizeof(NiLight) == 0xF0);
+static_assert(sizeof(NiLight) == 0xF0);
 
 class NiPointLight : public NiLight {
 public:
@@ -597,13 +597,13 @@ public:
 	float			Atten1;		// F4
 	float			Atten2;		// F8
 };
-assert(sizeof(NiPointLight) == 0xFC);
+static_assert(sizeof(NiPointLight) == 0xFC);
 
 class NiDirectionalLight : public NiLight {
 public:
 	NiPoint3		direction;			// F0
 };
-assert(sizeof(NiDirectionalLight) == 0xFC);
+static_assert(sizeof(NiDirectionalLight) == 0xFC);
 
 class NiVBChip {
 public:
@@ -616,7 +616,7 @@ public:
 	NiVBChip*				Next;		// 18
 	NiVBChip*				Prev;		// 1C
 };
-assert(sizeof(NiVBChip) == 0x020);
+static_assert(sizeof(NiVBChip) == 0x020);
 
 class NiGeometryBufferData {
 public:
@@ -644,7 +644,7 @@ public:
 	UInt16*							ArrayLengths;			// 4C
 	UInt16*							IndexArray;				// 50
 };
-assert(sizeof(NiGeometryBufferData) == 0x54);
+static_assert(sizeof(NiGeometryBufferData) == 0x54);
 
 class NiGeometryData : public NiObject {
 public:
@@ -676,7 +676,7 @@ public:
 	UInt8						Unk03C;				// 03C
 	UInt8						pad03C[3];
 };
-assert(sizeof(NiGeometryData) == 0x40);
+static_assert(sizeof(NiGeometryData) == 0x40);
 
 class NiSkinPartition : public NiObject {
 public:
@@ -698,7 +698,7 @@ public:
 	UInt32		PartitionsCount;		// 08
 	Partition*	Partitions;				// 0C
 };
-assert(sizeof(NiSkinPartition) == 0x10);
+static_assert(sizeof(NiSkinPartition) == 0x10);
 
 class NiSkinData : public NiObject {
 public:
@@ -722,7 +722,7 @@ public:
 	BoneData*			BoneData;			// 40
 	UInt32				Bones;				// 44
 };
-assert(sizeof(NiSkinData) == 0x48);
+static_assert(sizeof(NiSkinData) == 0x48);
 
 class NiSkinInstance : public NiObject {
 public:
@@ -741,7 +741,7 @@ public:
 	bool IsPartitionEnabled(UInt32 partitionIndex);
     
 };
-assert(sizeof(NiSkinInstance) == 0x34);
+static_assert(sizeof(NiSkinInstance) == 0x34);
 
 class DismemberPartition {
 public:
@@ -749,7 +749,7 @@ public:
     UInt8 StartCap;  //Questionable, but it's the only way I can make sense of that code
     UInt16 bodyPart;
 }; 
-assert(sizeof(DismemberPartition) == 4);
+static_assert(sizeof(DismemberPartition) == 4);
 
 class BSDismemberSkinInstance : public NiSkinInstance {
 public:
@@ -758,7 +758,7 @@ public:
     UInt8  IsRenderable;  //In Load this is made in OR with every partition->Enabled flag
     UInt8  pad[3];
 };
-assert(sizeof(BSDismemberSkinInstance) == 0x40);
+static_assert(sizeof(BSDismemberSkinInstance) == 0x40);
 
 class NiProperty : public NiObjectNET {
 public:
@@ -772,7 +772,7 @@ public:
 	};
     virtual PropertyType GetPropertyType();
 };
-assert(sizeof(NiProperty) == 0x18);
+static_assert(sizeof(NiProperty) == 0x18);
 
 class NiPropertyState {
 public:
@@ -801,7 +801,7 @@ public:
 	NiSkinInstance*		skinInstance;	// BC This seems to be a BSDismemberSkinInstance (old NiSkinInstance constructor is never used)
 	NiD3DShader*		shader;			// C0
 };
-assert(sizeof(NiGeometry) == 0xC4);
+static_assert(sizeof(NiGeometry) == 0xC4);
 
 class NiDX9TextureData : public NiObject {
 public:
@@ -818,7 +818,7 @@ public:
 	IDirect3DBaseTexture9*	dTexture;		// 64
 	UInt32					Levels;			// 68
 };
-assert(sizeof(NiDX9TextureData) == 0x6C);
+static_assert(sizeof(NiDX9TextureData) == 0x6C);
 
 class NiDX9SourceTextureData : public NiDX9TextureData {
 public:
@@ -831,7 +831,7 @@ public:
 	UInt32					SourceRevID;		// 7C
 	UInt32					PalRevID;			// 80
 };
-assert(sizeof(NiDX9SourceTextureData) == 0x84);
+static_assert(sizeof(NiDX9SourceTextureData) == 0x84);
 
 class NiTexture : public NiObjectNET {
 public:
@@ -885,7 +885,7 @@ public:
 	NiTexture*			nextTex;		// 028 - linked list updated in ctor/dtor
 	NiTexture*			prevTex;		// 02C
 };
-assert(sizeof(NiTexture) == 0x30);
+static_assert(sizeof(NiTexture) == 0x30);
 
 class NiSourceTexture : public NiTexture {
 public:
@@ -900,7 +900,7 @@ public:
 	UInt32			unk40;			// 40
 	UInt32			unk44;			// 44
 };
-assert(sizeof(NiSourceTexture) == 0x48);
+static_assert(sizeof(NiSourceTexture) == 0x48);
 
 class NiRenderedTexture : public NiTexture {
 public:
@@ -911,7 +911,7 @@ public:
 	UInt32		unk038;		// 038
 	UInt32		unk03C;		// 03C
 };
-assert(sizeof(NiRenderedTexture) == 0x040);
+static_assert(sizeof(NiRenderedTexture) == 0x040);
 
 class NiD3DTextureStage;
 class NiD3DShaderConstantMap;
@@ -958,7 +958,7 @@ public:
 	UInt8						Unk029[3];		// 029
 
 };
-assert(sizeof(NiD3DShaderDeclaration) == 0x02C);
+static_assert(sizeof(NiD3DShaderDeclaration) == 0x02C);
 
 class NiDX9ShaderDeclaration : public NiD3DShaderDeclaration {
 public:
@@ -968,7 +968,7 @@ public:
 	UInt8		Unk035[3];		// 035
 
 };
-assert(sizeof(NiDX9ShaderDeclaration) == 0x038);
+static_assert(sizeof(NiDX9ShaderDeclaration) == 0x038);
 
 class NiD3DShaderProgram : public NiRefObject {
 public:
@@ -989,7 +989,7 @@ public:
 	NiDX9Renderer*		Renderer;			// 24
 	NiDX9RenderState*	RenderState;		// 28
 };
-assert(sizeof(NiD3DShaderProgram) == 0x2C);
+static_assert(sizeof(NiD3DShaderProgram) == 0x2C);
 
 class NiD3DVertexShader : public NiD3DShaderProgram {
 public:
@@ -999,13 +999,13 @@ public:
 	IDirect3DVertexShader9*			ShaderHandle;	// 34
 	IDirect3DVertexDeclaration9*	Declaration;	// 38
 };
-assert(sizeof(NiD3DVertexShader) == 0x3C);
+static_assert(sizeof(NiD3DVertexShader) == 0x3C);
 
 class NiD3DPixelShader : public NiD3DShaderProgram {
 public:
 	IDirect3DPixelShader9* ShaderHandle;	// 2C
 };
-assert(sizeof(NiD3DPixelShader) == 0x30);
+static_assert(sizeof(NiD3DPixelShader) == 0x30);
 
 class NiD3DPass {
 public:
@@ -1033,7 +1033,7 @@ public:
 	UInt8							pad[2];
 	UInt32							RefCount;					// 64
 };
-assert(sizeof(NiD3DPass) == 0x68);
+static_assert(sizeof(NiD3DPass) == 0x68);
 
 class NiShader : public NiRefObject {
 public:
@@ -1042,7 +1042,7 @@ public:
 	UInt8		Unk010;					// 010
 	UInt8		pad010[3];
 };
-assert(sizeof(NiShader) == 0x14);
+static_assert(sizeof(NiShader) == 0x14);
 
 class NiD3DShaderInterface : public NiShader {
 public:
@@ -1052,7 +1052,7 @@ public:
 	UInt8				Unk020;			// 020
 	UInt8				pad01C[3];
 };
-assert(sizeof(NiD3DShaderInterface) == 0x24);
+static_assert(sizeof(NiD3DShaderInterface) == 0x24);
 
 class NiD3DShader : public NiD3DShaderInterface {
 public:
@@ -1065,7 +1065,7 @@ public:
 	NiD3DShaderConstantMap* VertexConstantMap;	// 034
 	UInt32					Unk038[14];			// 038
 };
-assert(sizeof(NiD3DShader) == 0x70);
+static_assert(sizeof(NiD3DShader) == 0x70);
 
 class BSShader : public NiD3DShader {
 public:
@@ -1073,7 +1073,7 @@ public:
 	UInt32		Unk074;			// 074
 	UInt32		Unk078;			// 078
 };
-assert(sizeof(BSShader) == 0x7C);
+static_assert(sizeof(BSShader) == 0x7C);
 
 class WaterShader : public BSShader {
 public:
@@ -1082,14 +1082,14 @@ public:
 	NiD3DPixelShader*	Pixel[38];		// 1A0
 	UInt32				Unk238[6];		// 238
 };
-assert(sizeof(WaterShader) == 0x250);
+static_assert(sizeof(WaterShader) == 0x250);
 
 
 class ShadowLightShader : public BSShader{
 public:
 	UInt32 unk07C[4];
 };
-assert(sizeof(ShadowLightShader) == 0x8C);
+static_assert(sizeof(ShadowLightShader) == 0x8C);
 
 
 class ParallaxShader : public ShadowLightShader{
@@ -1097,7 +1097,7 @@ public:
 	NiD3DVertexShader*  Vertex[20];
  	NiD3DPixelShader*   Pixel[33];
 };
-assert(sizeof(ParallaxShader) == 0x160);
+static_assert(sizeof(ParallaxShader) == 0x160);
 
 class BSImageSpaceShader : public BSShader {
 public:
@@ -1105,13 +1105,13 @@ public:
 	NiD3DVertexShader*	Vertex;		// 0C4
 	NiD3DPixelShader*	Pixel;		// 0C8
 };
-assert(sizeof(BSImageSpaceShader) == 0xCC);
+static_assert(sizeof(BSImageSpaceShader) == 0xCC);
 
 class WaterShaderHeightMap : public BSImageSpaceShader {
 public:
 	UInt32				Unk0CC;		// 0CC
 };
-assert(sizeof(WaterShaderHeightMap) == 0xD0);
+static_assert(sizeof(WaterShaderHeightMap) == 0xD0);
 
 class Ni2DBuffer : public NiObject {
 public:
@@ -1119,10 +1119,10 @@ public:
 	UInt32				height;	// 00C
 	NiDX92DBufferData*	data;	// 010
 };
-assert(sizeof(Ni2DBuffer) == 0x014);
+static_assert(sizeof(Ni2DBuffer) == 0x014);
 
 class NiDepthStencilBuffer : public Ni2DBuffer {};
-assert(sizeof(NiDepthStencilBuffer) == 0x014);
+static_assert(sizeof(NiDepthStencilBuffer) == 0x014);
 
 class NiDX92DBufferData : public NiRefObject {
 public:
@@ -1184,7 +1184,7 @@ public:
 	NiDepthStencilBuffer*			DepthStencilBuffer;			// 20
 	void*							RenderData;					// 24
 };
-assert(sizeof(NiRenderTargetGroup) == 0x28);
+static_assert(sizeof(NiRenderTargetGroup) == 0x28);
 
 class NiDX9RenderState : public NiRefObject {
 public:
@@ -1285,8 +1285,8 @@ public:
 	UInt32							unk1000[(0x1018 - 0x1000) >> 2];// 1100
 	D3DCAPS9						Caps;							// 1118
 };
-assert(offsetof(NiDX9RenderState, Device) == 0x10F8);
-assert(sizeof(NiDX9RenderState) == 0x1248);
+static_assert(offsetof(NiDX9RenderState, Device) == 0x10F8);
+static_assert(sizeof(NiDX9RenderState) == 0x1248);
 
 class NiRenderer : public NiObject {
 public:
@@ -1384,7 +1384,7 @@ public:
 	UInt32					Unk208;						// 208
 	UInt32					Unk20C;						// 20C
 };
-assert(sizeof(NiRenderer) == 0x210);
+static_assert(sizeof(NiRenderer) == 0x210);
 
 class NiDX9Renderer : public NiRenderer {
 public:
@@ -1514,7 +1514,7 @@ public:
 	RefreshRate						refreshRate;				// ACC
 	UInt32							UnkAD0[44];					// AD0
 };
-assert(sizeof(NiDX9Renderer) == 0xB80);
+static_assert(sizeof(NiDX9Renderer) == 0xB80);
 
 class NiControllerSequence : public NiObject {
 public:
@@ -1552,7 +1552,7 @@ public:
 	const char*				rootNodeName;			// 5C
 	UInt32					unk60[5];				// 60
 };
-assert(sizeof(NiControllerSequence) == 0x74);
+static_assert(sizeof(NiControllerSequence) == 0x74);
 
 class BSRenderedTexture : public NiObject {
 public:
@@ -1567,7 +1567,7 @@ public:
 	UInt32					unk038;				// 038
 	UInt32					unk03C;				// 03C
 };
-assert(sizeof(BSRenderedTexture) == 0x40);
+static_assert(sizeof(BSRenderedTexture) == 0x40);
 
 class NiAlphaProperty : public NiProperty {
 public:
@@ -1587,7 +1587,7 @@ public:
 	UInt8	alphaTestRef;	// 01A
 	UInt8	unk01B;			// 01B
 };
-assert(sizeof(NiAlphaProperty) == 0x01C);
+static_assert(sizeof(NiAlphaProperty) == 0x01C);
 
 class NiShadeProperty : public NiProperty {
 public:
@@ -1595,7 +1595,7 @@ public:
 	UInt8	pad01A[2];	// 01A
 	UInt32	Unk01C;		// 01C
 };
-assert(sizeof(NiShadeProperty) == 0x20);
+static_assert(sizeof(NiShadeProperty) == 0x20);
 
 class BSShaderProperty : public NiShadeProperty {
 public:
@@ -1663,7 +1663,7 @@ public:
 	UInt32	type;		// 058
 	float	Unk05C;		// 05C
 };
-assert(sizeof(BSShaderProperty) == 0x60);
+static_assert(sizeof(BSShaderProperty) == 0x60);
 
 class WaterShaderProperty : BSShaderProperty
 {
@@ -1731,7 +1731,7 @@ public:
   UInt32 dword148;
   UInt32 dword14C;
 };
-assert(sizeof(WaterShaderProperty) == 0x150);
+static_assert(sizeof(WaterShaderProperty) == 0x150);
 
 
 class BSShaderLightingProperty : public BSShaderProperty {
@@ -1744,7 +1744,7 @@ public:
 	UInt32	Unk074;	// 074
 	UInt32	Unk078;	// 078
 };
-assert(sizeof(BSShaderLightingProperty) == 0x7C);
+static_assert(sizeof(BSShaderLightingProperty) == 0x7C);
 
 class BSShaderPPLightingProperty : public BSShaderLightingProperty {
 public:
@@ -1781,13 +1781,13 @@ public:
 	UInt32		Unk0FC;	// 0FC
 	UInt32		Unk100;	// 100
 };
-assert(sizeof(BSShaderPPLightingProperty) == 0x104);
+static_assert(sizeof(BSShaderPPLightingProperty) == 0x104);
 
 class SpeedTreeShaderLightingProperty : public BSShaderLightingProperty {
 public:
 	UInt32	Unk07C[3];	// 07C
 };
-assert(sizeof(SpeedTreeShaderLightingProperty) == 0x88);
+static_assert(sizeof(SpeedTreeShaderLightingProperty) == 0x88);
 
 class SpeedTreeLeafShaderProperty : public SpeedTreeShaderLightingProperty {
 public:
@@ -1799,7 +1799,7 @@ public:
 
 	LeafData*	leafData;	// 088
 };
-assert(sizeof(SpeedTreeLeafShaderProperty) == 0x8C);
+static_assert(sizeof(SpeedTreeLeafShaderProperty) == 0x8C);
 
 class BSFadeNode : public NiNode {
 public:
@@ -1814,7 +1814,7 @@ public:
 	TESObjectREFR*	unkCC;			// CC
 	UInt32			unkD0[5];		// D0
 };
-assert(sizeof(BSFadeNode) == 0xE4);
+static_assert(sizeof(BSFadeNode) == 0xE4);
 
 class BSTreeModel : public NiRefObject {
 public:
@@ -1838,7 +1838,7 @@ public:
 	float					Unk48;				// 48
 	float					Unk4C;				// 4C
 };
-assert(sizeof(BSTreeModel) == 0x50);
+static_assert(sizeof(BSTreeModel) == 0x50);
 
 class BSTreeNode : public BSFadeNode {
 public:
@@ -1848,7 +1848,7 @@ public:
 	UInt32				UnkE8;			// F0
 	float				UnkEC;			// F4
 };
-assert(sizeof(BSTreeNode) == 0xF8);
+static_assert(sizeof(BSTreeNode) == 0xF8);
 
 class ShadowSceneLight : public NiRefObject {
 public:
@@ -1883,7 +1883,7 @@ public:
 	void*					portalGraph;		// 240 BSPortalGraph*
 	UInt32					unk244[3];			// 244
 };
-assert(sizeof(ShadowSceneLight) == 0x250);
+static_assert(sizeof(ShadowSceneLight) == 0x250);
 
 class ShadowSceneNode : public NiNode {
 public:
@@ -1933,4 +1933,4 @@ public:
 	UInt8								byte1FC;			// 1FC
 	UInt8								pad1FD[3];			// 1FD
 };
-assert(sizeof(ShadowSceneNode) == 0x200);
+static_assert(sizeof(ShadowSceneNode) == 0x200);

--- a/TESReloaded/Framework/Oblivion/Framework.h
+++ b/TESReloaded/Framework/Oblivion/Framework.h
@@ -2,7 +2,6 @@
 #pragma warning (disable: 4244) //disable warning for possible loss of data in implicit cast between int, float and double
 
 #define DETOURS_INTERNAL
-#define assert(a) static_assert(a, "Assertion failed")
 #define DIRECTINPUT_VERSION 0x0800
 
 #include <windows.h>

--- a/TESReloaded/Framework/Oblivion/Game.h
+++ b/TESReloaded/Framework/Oblivion/Game.h
@@ -3585,7 +3585,7 @@ public:
 		UInt8			pad1B;		// 1B
 	};
 	
-	Tile::Value* Tile::GetValueByType(UInt32 valueType) {
+	Tile::Value* GetValueByType(UInt32 valueType) {
 
 		for (NiTList<Value>::Entry* node = valueList.start; node; node = node->next) {
 			if (node->data && node->data->id == valueType) return node->data;
@@ -3594,7 +3594,7 @@ public:
 
 	}
 
-	bool Tile::GetFloatValue(UInt32 valueType, float* out) {
+	bool GetFloatValue(UInt32 valueType, float* out) {
 
 		Value* val = GetValueByType(valueType);
 

--- a/TESReloaded/Framework/Oblivion/Game.h
+++ b/TESReloaded/Framework/Oblivion/Game.h
@@ -54,7 +54,7 @@ class TESLoadScreen;
 class TESEffectShader;
 class TESRegionDataManager;
 class TESPackageData;
-class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; assert(sizeof(TESChildCell) == 0x004);
+class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; static_assert(sizeof(TESChildCell) == 0x004);
 
 class BSBound;
 class BSFogProperty;
@@ -81,7 +81,7 @@ public:
 	UInt32		typeID;		// ParamType
 	UInt32		isOptional;
 };
-assert(sizeof(CommandParam) == 0x00C);
+static_assert(sizeof(CommandParam) == 0x00C);
 
 class CommandArgs {
 public:
@@ -94,7 +94,7 @@ public:
 	double*			 result;		// 18
 	UInt32*			 opcodeOffset;	// 1C
 };
-assert(sizeof(CommandArgs) == 0x020);
+static_assert(sizeof(CommandArgs) == 0x020);
 
 class CommandInfo {
 public:
@@ -110,7 +110,7 @@ public:
 	void*			eval;			// 20
 	UInt32			flags;			// 24
 };
-assert(sizeof(CommandInfo) == 0x028);
+static_assert(sizeof(CommandInfo) == 0x028);
 
 template <typename T>
 class TList {
@@ -144,7 +144,7 @@ public:
 
 	Entry First;
 };
-assert(sizeof(TList<void>) == 0x008);
+static_assert(sizeof(TList<void>) == 0x008);
 
 class RGBA {
 public:
@@ -153,7 +153,7 @@ public:
 	UInt8	b;
 	UInt8	a;
 };
-assert(sizeof(RGBA) == 0x004);
+static_assert(sizeof(RGBA) == 0x004);
 
 class BSString {
 public:
@@ -163,7 +163,7 @@ public:
 	UInt16		m_dataLen;  // 04
 	UInt16		m_bufLen;	// 06
 };
-assert(sizeof(BSString) == 0x008);
+static_assert(sizeof(BSString) == 0x008);
 
 class BSFixedString {
 public:
@@ -172,7 +172,7 @@ public:
 	bool operator == (const BSFixedString& lhs) const { return m_data == lhs.m_data; }
 	bool operator < (const BSFixedString& lhs) const { return m_data < lhs.m_data; }
 };
-assert(sizeof(BSFixedString) == 0x04);
+static_assert(sizeof(BSFixedString) == 0x04);
 
 class BSExtraData {
 public:
@@ -272,7 +272,7 @@ public:
 	UInt8			pad[3];		// 005
 	BSExtraData*	next;		// 008
 };
-assert(sizeof(BSExtraData) == 0x0C);
+static_assert(sizeof(BSExtraData) == 0x0C);
 
 class InventoryChanges : public BSExtraData {
 public:
@@ -295,14 +295,14 @@ public:
 
 	Data*	data;			// 00C
 };
-assert(sizeof(InventoryChanges) == 0x10);
+static_assert(sizeof(InventoryChanges) == 0x10);
 
 class ExtraHavok : public BSExtraData {
 public:
 	bhkRefObject*	world;	// 00C bhkWorld
 	UInt32			unk10;	// 010
 };
-assert(sizeof(ExtraHavok) == 0x014);
+static_assert(sizeof(ExtraHavok) == 0x014);
 
 
 class ExtraRefractionProperty : public BSExtraData
@@ -310,7 +310,7 @@ class ExtraRefractionProperty : public BSExtraData
 public:
 	float		refractionAmount;		// range of 0-1
 };
-assert(sizeof(ExtraRefractionProperty) == 0x010);
+static_assert(sizeof(ExtraRefractionProperty) == 0x010);
 
 class ExtraDataList {
 public:
@@ -325,7 +325,7 @@ public:
 	BSExtraData*			m_data;					// 004
 	UInt8					m_presenceBitfield[12];	// 008 - if a bit is set, then the extralist should contain that extradata - bits are numbered starting from the lsb
 };
-assert(sizeof(ExtraDataList) == 0x14);
+static_assert(sizeof(ExtraDataList) == 0x14);
 
 class MagicCaster {
 public:
@@ -361,7 +361,7 @@ public:
 	NiNode* magicNode;		// 004 cached during casting anim
 	UInt32	state;			// 008
 };
-assert(sizeof(MagicCaster) == 0x0C);
+static_assert(sizeof(MagicCaster) == 0x0C);
 
 class MagicTarget {
 public:
@@ -372,7 +372,7 @@ public:
 	UInt8	unk04;			// 004
 	UInt8	pad05[3];
 };
-assert(sizeof(MagicTarget) == 0x08);
+static_assert(sizeof(MagicTarget) == 0x08);
 
 class ActorValues {
 public:
@@ -386,7 +386,7 @@ public:
 	Entry*			fatigue;		// 0C
 	Entry**			avArray;		// 10 array of more AV modifiers, size 0x12?
 };
-assert(sizeof(ActorValues) == 0x14);
+static_assert(sizeof(ActorValues) == 0x14);
 
 class BaseFormComponent {
 public:
@@ -395,7 +395,7 @@ public:
 	virtual void	CopyFromBase(BaseFormComponent* component);
 	virtual bool	CompareWithBase(BaseFormComponent* src);
 };
-assert(sizeof(BaseFormComponent) == 0x004);
+static_assert(sizeof(BaseFormComponent) == 0x004);
 
 class TESDescription : public BaseFormComponent {
 public:
@@ -403,7 +403,7 @@ public:
 
 	UInt32	formDiskOffset;	// 04
 };
-assert(sizeof(TESDescription) == 0x008);
+static_assert(sizeof(TESDescription) == 0x008);
 
 class TESModel : public BaseFormComponent {
 public:
@@ -417,10 +417,10 @@ public:
 	UInt8		pad11[3];
 	void*		unk14;		// 014
 };
-assert(sizeof(TESModel) == 0x018);
+static_assert(sizeof(TESModel) == 0x018);
 
 class TESModelAnim : public TESModel {};
-assert(sizeof(TESModelAnim) == 0x018);
+static_assert(sizeof(TESModelAnim) == 0x018);
 
 class TESScriptableForm : public BaseFormComponent {
 public:
@@ -428,7 +428,7 @@ public:
 	UInt8	unk1;		// 008
 	UInt8	pad[3];		// 009
 };
-assert(sizeof(TESScriptableForm) == 0x00C);
+static_assert(sizeof(TESScriptableForm) == 0x00C);
 
 class TESEnchantableForm : public BaseFormComponent {
 public:
@@ -437,32 +437,32 @@ public:
 	UInt16			 unk1;			// 0A
 	UInt32			 unk2;			// 0C
 };
-assert(sizeof(TESEnchantableForm) == 0x010);
+static_assert(sizeof(TESEnchantableForm) == 0x010);
 
 class TESValueForm : public BaseFormComponent {
 public:
 	UInt32	value;
 };
-assert(sizeof(TESValueForm) == 0x008);
+static_assert(sizeof(TESValueForm) == 0x008);
 
 class TESWeightForm : public BaseFormComponent {
 public:
 	float	weight;
 };
-assert(sizeof(TESWeightForm) == 0x008);
+static_assert(sizeof(TESWeightForm) == 0x008);
 
 class TESHealthForm : public BaseFormComponent {
 public:
 	UInt32	health;
 };
-assert(sizeof(TESHealthForm) == 0x008);
+static_assert(sizeof(TESHealthForm) == 0x008);
 
 class TESAttackDamageForm : public BaseFormComponent {
 public:
 	UInt16	damage;
 	UInt16	unk0;	// bitmask? perhaps 2 UInt8s?
 };
-assert(sizeof(TESAttackDamageForm) == 0x008);
+static_assert(sizeof(TESAttackDamageForm) == 0x008);
 
 class TESForm : public BaseFormComponent {
 public:
@@ -625,7 +625,7 @@ public:
 	UInt32				refID;					// 00C
 	TList<ModInfo>		modRefList;				// 010
 };
-assert(sizeof(TESForm) == 0x018);
+static_assert(sizeof(TESForm) == 0x018);
 
 class TESPackage : public TESForm {
 public:
@@ -864,7 +864,7 @@ public:
 	Time			time;					// 02C
 	TList<void*>	conditions;				// 034 ConditionEntry
 };
-assert(sizeof(TESPackage) == 0x3C);
+static_assert(sizeof(TESPackage) == 0x3C);
 
 class TESIdleForm : public TESForm {
 public:
@@ -889,22 +889,22 @@ public:
 	TESIdleForm*	parent;			// 40
 	TESIdleForm*	previous;		// 44
 };
-assert(sizeof(TESIdleForm) == 0x48);
+static_assert(sizeof(TESIdleForm) == 0x48);
 
 class TESTexture : public BaseFormComponent {
 public:
 	BSString	ddsPath;		// 04
 };
-assert(sizeof(TESTexture) == 0x0C);
+static_assert(sizeof(TESTexture) == 0x0C);
 
 class TESIcon : public TESTexture { };
-assert(sizeof(TESIcon) == 0x0C);
+static_assert(sizeof(TESIcon) == 0x0C);
 
 class TESFullName : public BaseFormComponent {
 public:
 	BSString	name;		// 004
 };
-assert(sizeof(TESFullName) == 0x0C);
+static_assert(sizeof(TESFullName) == 0x0C);
 
 class TESWeather : public TESForm {
 public:
@@ -1017,14 +1017,14 @@ public:
 	TList<SoundData>	sounds;						// 108
 	float				hdrInfo[14];				// 110
 };
-assert(sizeof(TESWeather) == 0x148);
+static_assert(sizeof(TESWeather) == 0x148);
 
 class TESWeatherEx : public TESWeather {
 public:
 	ColorData	colorsb[kNumColorTypes];
 	char		EditorName[40];
 };
-assert(sizeof(TESWeatherEx) == 0x210);
+static_assert(sizeof(TESWeatherEx) == 0x210);
 
 class TESClimate : public TESForm {
 public:
@@ -1051,7 +1051,7 @@ public:
 	UInt8				phaseLength;
 	UInt8				pad[2];
 };
-assert(sizeof(TESClimate) == 0x058);
+static_assert(sizeof(TESClimate) == 0x058);
 
 class TESWaterForm : public TESForm {
 public:
@@ -1099,7 +1099,7 @@ public:
 	float				displacementSimVals[5];	// 8C
 	UInt32				unkA0[3];				// A0 look like pointers to day/night/underwater water forms
 };
-assert(sizeof(TESWaterForm) == 0x0AC);
+static_assert(sizeof(TESWaterForm) == 0x0AC);
 
 class TESWorldSpace : public TESForm {
 public:
@@ -1131,7 +1131,7 @@ public:
 	NiTMap<UInt32, void>			map0C8;				// 0C8
 	UInt32							unk0D8[2];	// 0D8
 };
-assert(sizeof(TESWorldSpace) == 0x0E0);
+static_assert(sizeof(TESWorldSpace) == 0x0E0);
 
 class TESGlobal : public TESForm {
 public:
@@ -1140,7 +1140,7 @@ public:
 	UInt8		pad21[3];	// 021
 	float		data;		// 024
 };
-assert(sizeof(TESGlobal) == 0x028);
+static_assert(sizeof(TESGlobal) == 0x028);
 
 class TESSkill : public TESForm {
 public:
@@ -1178,7 +1178,7 @@ public:
 	TESDescription	levelQuote[4];	// 040
 
 };
-assert(sizeof(TESSkill) == 0x060);
+static_assert(sizeof(TESSkill) == 0x060);
 
 class TESRegion : public TESForm {
 public:
@@ -1188,13 +1188,13 @@ public:
 	TESWeather*		weather;		// 024
 	float			unk028;			// 028
 };
-assert(sizeof(TESRegion) == 0x02C);
+static_assert(sizeof(TESRegion) == 0x02C);
 
 class TESRegionEx : public TESRegion {
 public:
 	char		EditorName[40];		// 2C
 };
-assert(sizeof(TESRegionEx) == 0x054);
+static_assert(sizeof(TESRegionEx) == 0x054);
 
 class Script : public TESForm {
 public:
@@ -1241,7 +1241,7 @@ public:
 	TList<RefVariable>		refList;				// 040 - ref variables and immediates
 	TList<VariableInfo>		varList;				// 048 - local variable list
 };
-assert(sizeof(Script) == 0x50);
+static_assert(sizeof(Script) == 0x50);
 
 class TESQuest : public TESForm {
 public:
@@ -1315,7 +1315,7 @@ public:
 	UInt8				pad1[3];			// 05D
 	BSString			editorName;			// 060
 };
-assert(sizeof(TESQuest) == 0x068);
+static_assert(sizeof(TESQuest) == 0x068);
 
 class TESObject : public TESForm {
 public:
@@ -1334,7 +1334,7 @@ public:
 	virtual void	Unk_43();
 	virtual void	Unk_44();
 };
-assert(sizeof(TESObject) == 0x018);
+static_assert(sizeof(TESObject) == 0x018);
 
 class TESBoundObject : public TESObject {
 public:
@@ -1347,17 +1347,17 @@ public:
 	TESBoundObject*		 next;	// 020
 
 };
-assert(sizeof(TESBoundObject) == 0x024);
+static_assert(sizeof(TESBoundObject) == 0x024);
 
 class TESBoundAnimObject : public TESBoundObject {};
-assert(sizeof(TESBoundAnimObject) == 0x24);
+static_assert(sizeof(TESBoundAnimObject) == 0x24);
 
 class TESSoundFile : public BaseFormComponent {
 public:
 	BSString	fileName;	// 004
 	BSString	editorID;	// 00C
 };
-assert(sizeof(TESSoundFile) == 0x014);
+static_assert(sizeof(TESSoundFile) == 0x014);
 
 class TESSound : public TESBoundAnimObject {
 public:
@@ -1381,7 +1381,7 @@ public:
 	UInt16			staticAttenuation;	// 040 - CS value * -100
 	UInt16			unk12;				// 042 related to start/end times
 };
-assert(sizeof(TESSound) == 0x44);
+static_assert(sizeof(TESSound) == 0x44);
 
 class TESObjectLIGH : public TESBoundAnimObject {
 public:
@@ -1413,7 +1413,7 @@ public:
 	float				fade;		// 088
 	TESSound*			loopSound;	// 08C
 };
-assert(sizeof(TESObjectLIGH) == 0x90);
+static_assert(sizeof(TESObjectLIGH) == 0x90);
 
 class TESObjectWEAP : public TESBoundObject {
 public:
@@ -1501,7 +1501,7 @@ public:
 	TESWorldSpace*		 worldSpace;	// 050
 	NiNode*				 niNode;		// 054
 };
-assert(sizeof(TESObjectCELL) == 0x058);
+static_assert(sizeof(TESObjectCELL) == 0x058);
 
 class BaseProcess {
 public:
@@ -1838,7 +1838,7 @@ public:
 	TESPackage::eProcedure	editorPackProcedure;	// 004
 	TESPackage*				editorPackage;			// 008
 };
-assert(sizeof(BaseProcess) == 0x0C);
+static_assert(sizeof(BaseProcess) == 0x0C);
 
 class LowProcess : public BaseProcess {
 public:
@@ -1903,7 +1903,7 @@ public:
 	float			unk088;				// 088 - counter in seconds
 	float			unk08C;				// 08C
 };
-assert(sizeof(LowProcess) == 0x90);
+static_assert(sizeof(LowProcess) == 0x90);
 
 class MiddleLowProcess : public LowProcess {
 public:
@@ -1912,7 +1912,7 @@ public:
 	UInt32			unk090;				// 090
 	ActorValues		maxAVModifiers;		// 094
 };
-assert(sizeof(MiddleLowProcess) == 0xA8);
+static_assert(sizeof(MiddleLowProcess) == 0xA8);
 
 class MiddleHighProcess : public MiddleLowProcess {
 public:
@@ -2012,7 +2012,7 @@ public:
 	NiObject*			unk184;	// 184 - seen BSShaderPPLightingProperty
 	BSBound*			boundingBox;	// 188
 };
-assert(sizeof(MiddleHighProcess) == 0x18C);
+static_assert(sizeof(MiddleHighProcess) == 0x18C);
 
 class HighProcess : public MiddleHighProcess {
 public:
@@ -2218,7 +2218,7 @@ public:
 	UInt8					unk2E8;		// 2E8
 	UInt8					pad2E9[3];	// 2E9
 };
-assert(sizeof(HighProcess) == 0x2EC);
+static_assert(sizeof(HighProcess) == 0x2EC);
 
 class HighProcessEx : public HighProcess {
 public:
@@ -2247,7 +2247,7 @@ public:
 	UInt8							OnBeltActionState;
 	UInt8							OnBeltState;
 };
-assert(sizeof(HighProcessEx) == 0x300);
+static_assert(sizeof(HighProcessEx) == 0x300);
 
 class TESObjectREFR : public TESForm {
 public:
@@ -2340,7 +2340,7 @@ public:
 	TESObjectCELL*		parentCell;		// 040
 	ExtraDataList		extraDataList;	// 044
 };
-assert(sizeof(TESObjectREFR) == 0x058);
+static_assert(sizeof(TESObjectREFR) == 0x058);
 
 class MobileObject : public TESObjectREFR {
 public:
@@ -2371,7 +2371,7 @@ public:
 
 	BaseProcess*	process;			// 058
 };
-assert(sizeof(MobileObject) == 0x05C);
+static_assert(sizeof(MobileObject) == 0x05C);
 
 class Actor : public MobileObject {
 public:
@@ -2619,20 +2619,20 @@ public:
 	UInt8			pad0FC[2];						// 0FE
 	float			unk100;							// 100
 };
-assert(sizeof(Actor) == 0x104);
+static_assert(sizeof(Actor) == 0x104);
 
 class Creature : public Actor {
 public:
 	UInt32		unk104;				// 104
 };
-assert(sizeof(Creature) == 0x108);
+static_assert(sizeof(Creature) == 0x108);
 
 class Character : public Actor {
 public:
 	SkinInfo*	ActorSkinInfo;						// 104
 	UInt32		unk108;								// 108
 };
-assert(sizeof(Character) == 0x10C);
+static_assert(sizeof(Character) == 0x10C);
 
 class PlayerCharacter : public Character {
 public:
@@ -2841,13 +2841,13 @@ public:
 	float			unk7FC;							// 7FC
 	float			unk800;							// 800
 };
-assert(sizeof(PlayerCharacter) == 0x804);
+static_assert(sizeof(PlayerCharacter) == 0x804);
 
 class PlayerCharacterEx : public PlayerCharacter {
 public:
 	NiPoint3	ReticleOffset;
 };
-assert(sizeof(PlayerCharacterEx) == 0x810);
+static_assert(sizeof(PlayerCharacterEx) == 0x810);
 
 class SkinInfo {
 public:
@@ -2937,7 +2937,7 @@ public:
 	UInt32			unk14C;
 	Actor*			Actor150;				// 150
 };
-assert(sizeof(SkinInfo) == 0x154);
+static_assert(sizeof(SkinInfo) == 0x154);
 
 class AnimSequenceBase {
 public:
@@ -2948,31 +2948,31 @@ public:
 	virtual BSAnimGroupSequence*	GetAnimGroupSequence(int Index); // Index is not used if Single (returns the anim); Index = -1 returns a random anim in the NiTList<BSAnimGroupSequence>* for Multiple
 	virtual void					Unk_05();
 };
-assert(sizeof(AnimSequenceBase) == 0x004);
+static_assert(sizeof(AnimSequenceBase) == 0x004);
 
 class AnimSequenceSingle : public AnimSequenceBase {
 public:
 	BSAnimGroupSequence*	Anim;		// 04
 };
-assert(sizeof(AnimSequenceSingle) == 0x008);
+static_assert(sizeof(AnimSequenceSingle) == 0x008);
 
 class AnimSequenceSingleEx : public AnimSequenceSingle {
 public:
 	BSAnimGroupSequence*	ORAnim;		// 0C
 };
-assert(sizeof(AnimSequenceSingleEx) == 0x00C);
+static_assert(sizeof(AnimSequenceSingleEx) == 0x00C);
 
 class AnimSequenceMultiple : public AnimSequenceBase {
 public:
 	NiTList<BSAnimGroupSequence>* Anims;	// 04
 };
-assert(sizeof(AnimSequenceMultiple) == 0x008);
+static_assert(sizeof(AnimSequenceMultiple) == 0x008);
 
 class AnimSequenceMultipleEx : public AnimSequenceMultiple {
 public:
 	BSAnimGroupSequence*	ORAnim;		// 0C
 };
-assert(sizeof(AnimSequenceMultipleEx) == 0x00C);
+static_assert(sizeof(AnimSequenceMultipleEx) == 0x00C);
 
 class ActorAnimData {
 public:
@@ -3026,13 +3026,13 @@ public:
 	UInt32						unkD4;					//D4
 	void*						unkD8;					//D8 looks like struct with idle anim transform data
 };
-assert(sizeof(ActorAnimData) == 0xDC);
+static_assert(sizeof(ActorAnimData) == 0xDC);
 
 class ActorAnimDataEx : public ActorAnimData {
 public:
 	NiTList<BSAnimGroupSequence>*	ORAnims;	// DC
 };
-assert(sizeof(ActorAnimDataEx) == 0xE0);
+static_assert(sizeof(ActorAnimDataEx) == 0xE0);
 
 class TESAnimGroup : public NiRefObject {
 public:
@@ -3098,7 +3098,7 @@ public:
 	UInt32		unk024;			//024
 	void*		unk028;			//028
 };
-assert(sizeof(TESAnimGroup) == 0x02C);
+static_assert(sizeof(TESAnimGroup) == 0x02C);
 
 class SkyObject {
 public:
@@ -3108,7 +3108,7 @@ public:
 
 	NiNode*			RootNode;						// 04	
 };
-assert(sizeof(SkyObject) == 0x008);
+static_assert(sizeof(SkyObject) == 0x008);
 
 class Sun : public SkyObject {
 public:
@@ -3122,7 +3122,7 @@ public:
 	UInt8				unk24;					// 24
 	UInt8				pad25[3];				// 25
 };
-assert(sizeof(Sun) == 0x028);
+static_assert(sizeof(Sun) == 0x028);
 
 class Atmosphere : public SkyObject {
 public:
@@ -3134,14 +3134,14 @@ public:
 	UInt8			pad18[3];
 
 };
-assert(sizeof(Atmosphere) == 0x01C);
+static_assert(sizeof(Atmosphere) == 0x01C);
 
 class Stars : public SkyObject {
 public:
 	UInt32			unk08;					// 08
 	float			unk0C;					// 0C
 };
-assert(sizeof(Stars) == 0x010);
+static_assert(sizeof(Stars) == 0x010);
 
 class Clouds : public SkyObject {
 public:
@@ -3150,7 +3150,7 @@ public:
 	UInt32			unk10;					// 10
 	UInt32			unk14;					// 14
 };
-assert(sizeof(Clouds) == 0x018);
+static_assert(sizeof(Clouds) == 0x018);
 
 class Moon : public SkyObject {
 public:
@@ -3184,7 +3184,7 @@ public:
 	float			unk74;					// 74
 	float			unk78;					// 78
 };
-assert(sizeof(Moon) == 0x07C);
+static_assert(sizeof(Moon) == 0x07C);
 
 class Precipitation {
 public:
@@ -3195,7 +3195,7 @@ public:
 	float			unk10;					// 10
 	TESModel*		Model;					// 14
 };
-assert(sizeof(Precipitation) == 0x018);
+static_assert(sizeof(Precipitation) == 0x018);
 
 class Sky {
 public:
@@ -3265,7 +3265,7 @@ public:
 
 	bool GetIsUnderWater() { return this->flags & Sky::kSkyFlag_IsUnderwater; }
 };
-assert(sizeof(Sky) == 0x104);
+static_assert(sizeof(Sky) == 0x104);
 
 class GridArray {
 public:
@@ -3280,7 +3280,7 @@ public:
 	virtual void Fn_08();
 	virtual void Fn_09();
 };
-assert(sizeof(GridArray) == 0x004);
+static_assert(sizeof(GridArray) == 0x004);
 
 class GridDistantArray : public GridArray {
 public:
@@ -3296,7 +3296,7 @@ public:
 	UInt32				size;		// 0C grid is size^2, size = uGridsToLoad + 2 * uGridDistantCount
 	DistantGridEntry*	grid;		// 10 dynamically alloc'ed array of GridEntry[size^2]
 };
-assert(sizeof(GridDistantArray) == 0x014);
+static_assert(sizeof(GridDistantArray) == 0x014);
 
 class GridCellArray : public GridArray {
 public:
@@ -3327,7 +3327,7 @@ public:
 	UInt8				pad20[3];
 	BSRenderedTexture*	canopyShadowMap;		// 24
 };
-assert(sizeof(GridCellArray) == 0x028);
+static_assert(sizeof(GridCellArray) == 0x028);
 
 class WaterManager {
 public:
@@ -3353,7 +3353,7 @@ public:
 	UInt32				unk40;					// 040
 	float				WaterHeight;			// 044
 };
-assert(sizeof(WaterManager) == 0x048);
+static_assert(sizeof(WaterManager) == 0x048);
 
 class TES {
 public:
@@ -3414,7 +3414,7 @@ public:
 	UInt8				unkA9;					// A9
 	UInt8				padA8[2];
 };
-assert(sizeof(TES) == 0x0AC);
+static_assert(sizeof(TES) == 0x0AC);
 
 class TESGameSound {
 public:
@@ -3439,13 +3439,13 @@ public:
 	UInt32			unk50;		// 50
 	UInt32			unk54;		// 54
 };
-assert(sizeof(TESGameSound) == 0x058);
+static_assert(sizeof(TESGameSound) == 0x058);
 
 class BSAnimGroupSequence : public NiControllerSequence {
 public:
 	TESAnimGroup*	animGroup;	//068
 };
-assert(sizeof(BSAnimGroupSequence) == 0x06C);
+static_assert(sizeof(BSAnimGroupSequence) == 0x06C);
 
 class Tile {
 public:
@@ -3618,7 +3618,7 @@ public:
 	UInt32			flags;		// 2C
 	NiTList<Tile>	childList;	// 30
 };
-assert(sizeof(Tile) == 0x040);
+static_assert(sizeof(Tile) == 0x040);
 
 class TileRect : public Tile {
 public:
@@ -3628,13 +3628,13 @@ public:
 
 	UInt32	unk40;	// 40
 };
-assert(sizeof(TileRect) == 0x044);
+static_assert(sizeof(TileRect) == 0x044);
 
 class TileMenu : public TileRect {
 public:
 	Menu*	menu;	// 44
 };
-assert(sizeof(TileMenu) == 0x048);
+static_assert(sizeof(TileMenu) == 0x048);
 
 class Menu {
 public:
@@ -3725,7 +3725,7 @@ public:
 	UInt32	  id;			// 20 - uninitialized
 	UInt32	  unk24;		// 24 - initialized to 4, is 8 if enabled?
 };
-assert(sizeof(Menu) == 0x028);
+static_assert(sizeof(Menu) == 0x028);
 
 class ModInfo {
 public:
@@ -3789,7 +3789,7 @@ public:
 	UInt32			unk414;							// 414
 	UInt32			unk418;							// 418
 };
-assert(sizeof(ModInfo) == 0x41C);
+static_assert(sizeof(ModInfo) == 0x41C);
 
 class ModList {
 public:
@@ -3797,7 +3797,7 @@ public:
 	UInt32				loadedModCount;		// 08
 	ModInfo*			loadedMods[0xFF];	// 0C
 };
-assert(sizeof(ModList) == 0x408);
+static_assert(sizeof(ModList) == 0x408);
 
 class MainDataHandler {
 public:
@@ -3867,7 +3867,7 @@ public:
 	TESRegionDataManager*	regionDataManager;				// CD8
 	UInt32					unkCDC;							// CDC
 };
-assert(sizeof(MainDataHandler) == 0xCE0);
+static_assert(sizeof(MainDataHandler) == 0xCE0);
 
 class InputControl {
 public:
@@ -3930,7 +3930,7 @@ public:
 	UInt8				 pad1BD6;									// 1BD6
 	UInt8				 pad1BD7;									// 1BD7
 };
-assert(sizeof(InputControl) == 0x1BD8);
+static_assert(sizeof(InputControl) == 0x1BD8);
 
 class SoundControl {
 public:
@@ -3983,7 +3983,7 @@ public:
 	NiTList<UInt32>*		soundMessageList;			// 320
 	UInt32					unk324;						// 324
 };
-assert(sizeof(SoundControl) == 0x328);
+static_assert(sizeof(SoundControl) == 0x328);
 
 class Main {
 public:
@@ -4026,7 +4026,7 @@ public:
 	InputControl*	input;				// 20
 	SoundControl*	sound;				// 24
 };
-assert(sizeof(Main) == 0x028);
+static_assert(sizeof(Main) == 0x028);
 
 class MenuInterfaceManager {
 public:
@@ -4077,7 +4077,7 @@ public:
 	UInt32			activeMenuType;					// 0E0
 	UInt32			unk0E4[(0x134 - 0x0E4) >> 2];	// 0E4
 };
-assert(sizeof(MenuInterfaceManager) == 0x134);
+static_assert(sizeof(MenuInterfaceManager) == 0x134);
 
 class TimeGlobals {
 public:
@@ -4091,7 +4091,7 @@ public:
 	static float GetGameTime() { TimeGlobals* Globals = (TimeGlobals*)0x00B332E0; return Globals->GameHour->data * 60.0f * 60.0f; }
 	static TimeGlobals* Get() { return (TimeGlobals*)0xB332E0; }
 };
-assert(sizeof(TimeGlobals) == 0x018); // Static class, size could be larger
+static_assert(sizeof(TimeGlobals) == 0x018); // Static class, size could be larger
 
 class QueuedModelLoader {
 public:
@@ -4100,7 +4100,7 @@ public:
 	UInt32	Unk000[7]; // LockFreeMaps for models
 
 };
-assert(sizeof(QueuedModelLoader) == 0x01C);
+static_assert(sizeof(QueuedModelLoader) == 0x01C);
 
 class GameSetting {
 public:
@@ -4111,7 +4111,7 @@ public:
 	};
 	char*		Name;
 };
-assert(sizeof(GameSetting) == 0x08);
+static_assert(sizeof(GameSetting) == 0x08);
 
 namespace Pointers {
 	namespace Generic {

--- a/TESReloaded/Framework/Oblivion/GameHavok.h
+++ b/TESReloaded/Framework/Oblivion/GameHavok.h
@@ -16,26 +16,26 @@ public:
 	float	z;
 	float	w;
 };
-assert(sizeof(hkVector4) == 0x010);
+static_assert(sizeof(hkVector4) == 0x010);
 
 class hkQuaternion {
 public:
 	hkVector4	vec;
 };
-assert(sizeof(hkQuaternion) == 0x010);
+static_assert(sizeof(hkQuaternion) == 0x010);
 
 class hkBaseObject {
 public:
 	virtual void Destructor(bool FreeThis);
 };
-assert(sizeof(hkBaseObject) == 0x004);
+static_assert(sizeof(hkBaseObject) == 0x004);
 
 class hkRefObject : public hkBaseObject {
 public:
 	UInt16		sizeAndFlags;	// 04
 	UInt16		refCount;		// 06
 };
-assert(sizeof(hkRefObject) == 0x008);
+static_assert(sizeof(hkRefObject) == 0x008);
 
 class bhkRefObject : public NiObject {
 public:
@@ -44,7 +44,7 @@ public:
 
 	hkRefObject*	hkObject;	// 008
 };
-assert(sizeof(bhkRefObject) == 0x00C);
+static_assert(sizeof(bhkRefObject) == 0x00C);
 
 class bhkSerializable : public bhkRefObject {
 public:
@@ -62,7 +62,7 @@ public:
 
 	void*			hkData;		// 00C
 };
-assert(sizeof(bhkSerializable) == 0x010);
+static_assert(sizeof(bhkSerializable) == 0x010);
 
 class bhkWorldObject : public bhkSerializable {
 public:
@@ -70,7 +70,7 @@ public:
 	virtual void	Unk_21();
 	virtual NiNode*	CreateNiGeometry(NiNode* Node);
 };
-assert(sizeof(bhkWorldObject) == 0x010);
+static_assert(sizeof(bhkWorldObject) == 0x010);
 
 class bhkRigidBody : public bhkWorldObject {
 public:
@@ -78,7 +78,7 @@ public:
 	UInt32			unk014;		// 014
 	UInt32			unk018;		// 018
 };
-assert(sizeof(bhkRigidBody) == 0x1C);
+static_assert(sizeof(bhkRigidBody) == 0x1C);
 
 class bhkRigidBodyT : public bhkRigidBody {
 public:
@@ -90,7 +90,7 @@ public:
 	UInt32			unk048;		// 048
 	UInt32			unk04C;		// 04C
 };
-assert(sizeof(bhkRigidBodyT) == 0x50);
+static_assert(sizeof(bhkRigidBodyT) == 0x50);
 
 class bhkShape : public bhkSerializable {
 public:
@@ -139,16 +139,16 @@ public:
 
 	UInt32			material;	// 010
 };
-assert(sizeof(bhkShape) == 0x14);
+static_assert(sizeof(bhkShape) == 0x14);
 
 class bhkPackedNiTriStripsShape : public bhkShape {};
-assert(sizeof(bhkPackedNiTriStripsShape) == 0x14);
+static_assert(sizeof(bhkPackedNiTriStripsShape) == 0x14);
 
 class NiCollisionObject : public NiObject {
 public:
 	NiAVObject*		SceneObject;	// 008
 };
-assert(sizeof(NiCollisionObject) == 0x0C);
+static_assert(sizeof(NiCollisionObject) == 0x0C);
 
 class bhkCollisionObject : public NiCollisionObject {
 public:
@@ -163,13 +163,13 @@ public:
 	UInt8				pad00E[2];		// 00E
 	bhkRigidBody*		bRigidBody;		// 010
 };
-assert(sizeof(bhkCollisionObject) == 0x14);
+static_assert(sizeof(bhkCollisionObject) == 0x14);
 
 class bhkCollisionObjectEx : public bhkCollisionObject {
 public:
 	NiNode*			GeoNode;	// 014
 };
-assert(sizeof(bhkCollisionObjectEx) == 0x18);
+static_assert(sizeof(bhkCollisionObjectEx) == 0x18);
 
 class hkWorldRayCastInput {
 public:
@@ -180,7 +180,7 @@ public:
 	UInt32		FilterInfo;						// 24
 	UInt32		pad28[2];
 };
-assert(sizeof(hkWorldRayCastInput) == 0x30);
+static_assert(sizeof(hkWorldRayCastInput) == 0x30);
 
 class hkShapeRayCastOutput {
 public:
@@ -189,14 +189,14 @@ public:
 	float		HitFraction;			// 14
 	UInt32		pad18[2];
 };
-assert(sizeof(hkShapeRayCastOutput) == 0x20);
+static_assert(sizeof(hkShapeRayCastOutput) == 0x20);
 
 class hkWorldRayCastOutput : public hkShapeRayCastOutput {
 public:
 	hkCollidable*	RootCollidable;		// 20
 	UInt32			pad24[3];
 };
-assert(sizeof(hkWorldRayCastOutput) == 0x30);
+static_assert(sizeof(hkWorldRayCastOutput) == 0x30);
 
 class bhkWorldRayCastData {
 public:
@@ -212,7 +212,7 @@ public:
 	hkRayHitCollector*		RayHitCollector2;		// 78
 	UInt32					pad7C;
 };
-assert(sizeof(bhkWorldRayCastData) == 0x80);
+static_assert(sizeof(bhkWorldRayCastData) == 0x80);
 
 class hkWorld : public hkRefObject {
 public:
@@ -224,26 +224,26 @@ public:
 	hkVector4	gravity;				// 020
 	// More...
 };
-assert(sizeof(hkWorld) == 0x030);
+static_assert(sizeof(hkWorld) == 0x030);
 
 class hkShape : public hkRefObject {
 public:
 	bhkRefObject*		bRefObject;		// 008
 };
-assert(sizeof(hkShape) == 0x00C);
+static_assert(sizeof(hkShape) == 0x00C);
 
 class hkPackedNiTriStripsShape : public hkShape {
 public:
 	UInt32						unk0C;					// 00C
 	hkPackedNiTriStripsData*	PackedNiTriStripsData;	// 010
 };
-assert(sizeof(hkPackedNiTriStripsShape) == 0x14);
+static_assert(sizeof(hkPackedNiTriStripsShape) == 0x14);
 
 class hkScaledMoppBvTreeShape : public hkShape {
 public:
 	hkPackedNiTriStripsShape*	PackedNiTriStripsShape;		// 00C
 };
-assert(sizeof(hkScaledMoppBvTreeShape) == 0x010);
+static_assert(sizeof(hkScaledMoppBvTreeShape) == 0x010);
 
 class hkRigidBody : public hkRefObject {
 public:
@@ -285,4 +285,4 @@ public:
 	UInt16				unk08E;			// 08E
 	UInt32				unk090;
 };
-assert(sizeof(hkRigidBody) == 0x94);
+static_assert(sizeof(hkRigidBody) == 0x94);

--- a/TESReloaded/Framework/Oblivion/GameNi.h
+++ b/TESReloaded/Framework/Oblivion/GameNi.h
@@ -125,14 +125,14 @@ static_assert(sizeof(NiVector4) == 0x010);
 
 class NiMatrix33 {
 public:
-	NiPoint3 NiMatrix33::operator * (const NiPoint3 pt) const {
+	NiPoint3 operator * (const NiPoint3 pt) const {
 		return {
 			data[0][0] * pt.x + data[0][1] * pt.y + data[0][2] * pt.z,
 			data[1][0] * pt.x + data[1][1] * pt.y + data[1][2] * pt.z,
 			data[2][0] * pt.x + data[2][1] * pt.y + data[2][2] * pt.z
 		};
 	}
-	NiMatrix33 NiMatrix33::operator * (const NiMatrix33 mat) const {
+	NiMatrix33 operator * (const NiMatrix33 mat) const {
 		NiMatrix33 prd;
 
 		prd.data[0][0] =

--- a/TESReloaded/Framework/Oblivion/GameNi.h
+++ b/TESReloaded/Framework/Oblivion/GameNi.h
@@ -65,14 +65,14 @@ struct NiRTTI {
 	const char* name;
 	NiRTTI*		parent;
 };
-assert(sizeof(NiRTTI) == 0x008);
+static_assert(sizeof(NiRTTI) == 0x008);
 
 class NiPoint2 {
 public:
 	float	x;
 	float	y;
 };
-assert(sizeof(NiPoint2) == 0x008);
+static_assert(sizeof(NiPoint2) == 0x008);
 
 class NiPoint3 {
 public:
@@ -98,7 +98,7 @@ public:
 		return D3DXVECTOR4(x, y, z, 1.0);
 	}
 };
-assert(sizeof(NiPoint3) == 0x00C);
+static_assert(sizeof(NiPoint3) == 0x00C);
 
 class NiVector4 {
 public:
@@ -121,7 +121,7 @@ public:
 	float z;
 	float w;
 };
-assert(sizeof(NiVector4) == 0x010);
+static_assert(sizeof(NiVector4) == 0x010);
 
 class NiMatrix33 {
 public:
@@ -192,7 +192,7 @@ public:
 
 	float data[3][3];
 };
-assert(sizeof(NiMatrix33) == 0x024);
+static_assert(sizeof(NiMatrix33) == 0x024);
 
 class NiTransform {
 public:
@@ -200,7 +200,7 @@ public:
 	NiPoint3	pos;		// 24
 	float		scale;		// 30
 };
-assert(sizeof(NiTransform) == 0x034);
+static_assert(sizeof(NiTransform) == 0x034);
 
 class NiPlane {
 public:
@@ -213,7 +213,7 @@ public:
 	NiPoint3	Normal;
 	float		Constant;
 };
-assert(sizeof(NiPlane) == 0x010);
+static_assert(sizeof(NiPlane) == 0x010);
 
 class NiBound {
 public:
@@ -228,7 +228,7 @@ public:
 	NiPoint3	Center;
 	float		Radius;
 };
-assert(sizeof(NiBound) == 0x010);
+static_assert(sizeof(NiBound) == 0x010);
 
 class NiFrustum {
 public:
@@ -241,7 +241,7 @@ public:
 	UInt8	Ortho;		// 18
 	UInt8	pad18[3];
 };
-assert(sizeof(NiFrustum) == 0x01C);
+static_assert(sizeof(NiFrustum) == 0x01C);
 
 class NiFrustumPlanes {
 public:
@@ -258,7 +258,7 @@ public:
 	NiPlane	CullingPlanes[MaxPlanes];	// 00
 	UInt32	ActivePlanes;				// 60
 };
-assert(sizeof(NiFrustumPlanes) == 0x064);
+static_assert(sizeof(NiFrustumPlanes) == 0x064);
 
 class NiViewport {
 public:
@@ -267,7 +267,7 @@ public:
 	float	t;
 	float	b;
 };
-assert(sizeof(NiViewport) == 0x010);
+static_assert(sizeof(NiViewport) == 0x010);
 
 class NiColor {
 public:
@@ -275,7 +275,7 @@ public:
 	float	g;
 	float	b;
 };
-assert(sizeof(NiColor) == 0x00C);
+static_assert(sizeof(NiColor) == 0x00C);
 
 class NiColorAlpha {
 public:
@@ -284,7 +284,7 @@ public:
 	float	b;
 	float	a;
 };
-assert(sizeof(NiColorAlpha) == 0x010);
+static_assert(sizeof(NiColorAlpha) == 0x010);
 
 template <typename T>
 class NiTList {
@@ -303,7 +303,7 @@ public:
 	Entry*	end;		// 008
 	UInt32	numItems;	// 00C
 };
-assert(sizeof(NiTList<void>) == 0x010);
+static_assert(sizeof(NiTList<void>) == 0x010);
 
 template <typename TKey, typename TData>
 class NiTMap {
@@ -327,7 +327,7 @@ public:
 	Entry**			m_buckets;		// 8
 	UInt32			m_numItems;		// C
 };
-assert(sizeof(NiTMap<void, void>) == 0x010);
+static_assert(sizeof(NiTMap<void, void>) == 0x010);
 
 template <typename T>
 class NiTArray {
@@ -342,7 +342,7 @@ public:
 	UInt16		numObjs;		// 0C - init'd to 0
 	UInt16		growSize;		// 0E - init'd to size of preallocation
 };
-assert(sizeof(NiTArray<void>) == 0x010);
+static_assert(sizeof(NiTArray<void>) == 0x010);
 
 template <typename T>
 class NiTLargeArray {
@@ -354,7 +354,7 @@ public:
 	UInt32		numObjs;		// 10 - init'd to 0
 	UInt32		growSize;		// 14 - init'd to size of preallocation
 };
-assert(sizeof(NiTLargeArray<void>) == 0x018);
+static_assert(sizeof(NiTLargeArray<void>) == 0x018);
 
 class NiPixelFormat {
 public:
@@ -437,7 +437,7 @@ public:
 	UInt32			ExtraData;		// 10
 	NiComponentSpec	Components[4];	// 14
 };
-assert(sizeof(NiPixelFormat) == 0x044);
+static_assert(sizeof(NiPixelFormat) == 0x044);
 
 class NiRefObject {
 public:
@@ -445,7 +445,7 @@ public:
 
 	UInt32			m_uiRefCount;				// 004
 };
-assert(sizeof(NiRefObject) == 0x008);
+static_assert(sizeof(NiRefObject) == 0x008);
 
 class NiObject : public NiRefObject {
 public:
@@ -468,7 +468,7 @@ public:
 	virtual void		Unk_11();
 	virtual void		Unk_12(UInt32 arg);
 };
-assert(sizeof(NiObject) == 0x008);
+static_assert(sizeof(NiObject) == 0x008);
 
 class NiExtraData : public NiObject {
 public:
@@ -477,13 +477,13 @@ public:
 
 	char*	m_pcName;	// 08
 };
-assert(sizeof(NiExtraData) == 0x00C);
+static_assert(sizeof(NiExtraData) == 0x00C);
 
 class TESObjectExtraData : public NiExtraData {
 public:
 	TESObjectREFR*	refr;	// 0C
 };
-assert(sizeof(TESObjectExtraData) == 0x010);
+static_assert(sizeof(TESObjectExtraData) == 0x010);
 
 class NiObjectNET : public NiObject {
 public:
@@ -495,7 +495,7 @@ public:
 	UInt16				m_extraDataListLen;				// 014
 	UInt16				m_extraDataListCapacity;		// 016
 };
-assert(sizeof(NiObjectNET) == 0x018);
+static_assert(sizeof(NiObjectNET) == 0x018);
 
 class NiAVObject : public NiObjectNET {
 public:
@@ -550,7 +550,7 @@ public:
 	NiTList<NiProperty>		m_propertyList;			// 098
 	bhkCollisionObject*		m_spCollision;			// 0A8
 };
-assert(sizeof(NiAVObject) == 0x0AC);
+static_assert(sizeof(NiAVObject) == 0x0AC);
 
 class NiNode : public NiAVObject {
 public:
@@ -568,7 +568,7 @@ public:
 	NiTList<NiDynamicEffect*>	m_effects;			// 0BC
 	NiBound						m_combinedBounds;	// 0CC
 };
-assert(sizeof(NiNode) == 0x0DC);
+static_assert(sizeof(NiNode) == 0x0DC);
 
 class NiBillboardNode : public NiNode {
 public:
@@ -588,7 +588,7 @@ public:
 	UInt8	pad0DE[2];			// 0DE
 	float	lastUpdateTime;		// 0E0
 };
-assert(sizeof(NiBillboardNode) == 0x0E4);
+static_assert(sizeof(NiBillboardNode) == 0x0E4);
 
 class NiCamera : public NiAVObject {
 public:
@@ -599,7 +599,7 @@ public:
 	NiViewport	ViewPort;				// 110
 	float		LODAdjust;				// 120
 };
-assert(sizeof(NiCamera) == 0x124);
+static_assert(sizeof(NiCamera) == 0x124);
 
 class NiCullingProcess {
 public:
@@ -615,7 +615,7 @@ public:
 	NiFrustum		CameraFrustum;		// 10
 	NiFrustumPlanes	Planes;				// 2C
 };
-assert(sizeof(NiCullingProcess) == 0x90);
+static_assert(sizeof(NiCullingProcess) == 0x90);
 
 class SceneGraph : public NiNode {
 public:
@@ -629,7 +629,7 @@ public:
 	UInt8				pad0E8[3];
 	float				cameraFOV;				// 0EC
 };
-assert(sizeof(SceneGraph) == 0x0F0);
+static_assert(sizeof(SceneGraph) == 0x0F0);
 
 class NiDynamicEffect : public NiAVObject {
 public:
@@ -646,7 +646,7 @@ public:
 	NiTList<NiNode>		affectedNodes;		// 0BC
 	NiTList<NiNode>		unaffectedNodes;	// 0CC
 };
-assert(sizeof(NiDynamicEffect) == 0x0DC);
+static_assert(sizeof(NiDynamicEffect) == 0x0DC);
 
 class NiLight : public NiDynamicEffect {
 public:
@@ -656,7 +656,7 @@ public:
 	NiColor		Spec;		// 0F8
 	void*		unk104;		// 104
 };
-assert(sizeof(NiLight) == 0x108);
+static_assert(sizeof(NiLight) == 0x108);
 
 class NiPointLight : public NiLight {
 public:
@@ -664,13 +664,13 @@ public:
 	float	Atten1;		// 10C
 	float	Atten2;		// 110
 };
-assert(sizeof(NiPointLight) == 0x114);
+static_assert(sizeof(NiPointLight) == 0x114);
 
 class NiDirectionalLight : public NiLight {
 public:
 	NiPoint3	direction;	// 108
 };
-assert(sizeof(NiDirectionalLight) == 0x114);
+static_assert(sizeof(NiDirectionalLight) == 0x114);
 
 class NiProperty : public NiObjectNET {
 public:
@@ -690,7 +690,7 @@ public:
 	virtual UInt32	GetPropertyType();
 	virtual void	Update(float unk0);
 };
-assert(sizeof(NiProperty) == 0x018);
+static_assert(sizeof(NiProperty) == 0x018);
 
 class NiPropertyState : public NiRefObject {
 public:
@@ -706,7 +706,7 @@ public:
 	//  8 28 WireFrame
 	//  9 2C ZBuffer
 };
-assert(sizeof(NiPropertyState) == 0x030);
+static_assert(sizeof(NiPropertyState) == 0x030);
 
 class NiVBChip {
 public:
@@ -719,7 +719,7 @@ public:
 	NiVBChip*				Next;		// 18
 	NiVBChip*				Prev;		// 1C
 };
-assert(sizeof(NiVBChip) == 0x020);
+static_assert(sizeof(NiVBChip) == 0x020);
 
 class NiGeometryBufferData {
 public:
@@ -745,7 +745,7 @@ public:
 	UInt16*							ArrayLengths;			// 48
 	UInt16*							IndexArray;				// 4C
 };
-assert(sizeof(NiGeometryBufferData) == 0x050);
+static_assert(sizeof(NiGeometryBufferData) == 0x050);
 
 class NiGeometryData : public NiObject {
 public:
@@ -774,7 +774,7 @@ public:
 	UInt8						Unk03D;				// 03D
 	UInt8						pad03C[2];
 };
-assert(sizeof(NiGeometryData) == 0x040);
+static_assert(sizeof(NiGeometryData) == 0x040);
 
 class NiSkinPartition : public NiObject {
 public:
@@ -796,7 +796,7 @@ public:
 	UInt32		PartitionsCount;		// 08
 	Partition*	Partitions;				// 0C
 };
-assert(sizeof(NiSkinPartition) == 0x010);
+static_assert(sizeof(NiSkinPartition) == 0x010);
 
 class NiSkinData : public NiObject {
 public:
@@ -820,7 +820,7 @@ public:
 	UInt32				Bones;				// 40
 	BoneData*			BoneData;			// 44
 };
-assert(sizeof(NiSkinData) == 0x048);
+static_assert(sizeof(NiSkinData) == 0x048);
 
 class NiSkinInstance : public NiObject {
 public:
@@ -836,7 +836,7 @@ public:
 	
 	bool               IsPartitionEnabled(UInt32 partitionIndex) {return true;}
 };
-assert(sizeof(NiSkinInstance) == 0x02C);
+static_assert(sizeof(NiSkinInstance) == 0x02C);
 
 class NiGeometry : public NiAVObject {
 public:
@@ -854,7 +854,7 @@ public:
 	NiSkinInstance*			skinInstance;		// 0B8
 	NiD3DShader*			shader;				// 0BC BSShader
 };
-assert(sizeof(NiGeometry) == 0x0C0);
+static_assert(sizeof(NiGeometry) == 0x0C0);
 
 class NiDX9TextureData {
 public:
@@ -867,7 +867,7 @@ public:
 	UInt32					Height;			// 58
 	UInt32					Levels;			// 5C
 };
-assert(sizeof(NiDX9TextureData) == 0x060);
+static_assert(sizeof(NiDX9TextureData) == 0x060);
 
 class NiDX9SourceTextureData : public NiDX9TextureData {
 public:
@@ -881,7 +881,7 @@ public:
 	UInt32					SourceRevID;		// 74
 	UInt32					PalRevID;			// 78
 };
-assert(sizeof(NiDX9SourceTextureData) == 0x07C);
+static_assert(sizeof(NiDX9SourceTextureData) == 0x07C);
 
 class NiTexture : public NiObjectNET {
 public:
@@ -931,7 +931,7 @@ public:
 	NiTexture*			texPrev;		// 028
 	NiTexture*			texNext;		// 02C
 };
-assert(sizeof(NiTexture) == 0x030);
+static_assert(sizeof(NiTexture) == 0x030);
 
 class NiSourceTexture : public NiTexture {
 public:
@@ -949,7 +949,7 @@ public:
 	UInt8			pad042[2];			// 042
 	void*			unk044;				// 044
 };
-assert(sizeof(NiSourceTexture) == 0x048);
+static_assert(sizeof(NiSourceTexture) == 0x048);
 
 class NiRenderedTexture : public NiTexture {
 public:
@@ -962,7 +962,7 @@ public:
 	UInt8		unk03C;		// 03C
 	UInt8		pad03C;
 };
-assert(sizeof(NiRenderedTexture) == 0x040);
+static_assert(sizeof(NiRenderedTexture) == 0x040);
 
 class NiD3DTextureStage {
 public:
@@ -970,7 +970,7 @@ public:
 	NiTexture*			Texture;			// 04
 	UInt32				Unk08;				// 08
 };
-assert(sizeof(NiD3DTextureStage) == 0x00C);
+static_assert(sizeof(NiD3DTextureStage) == 0x00C);
 
 class NiD3DShaderConstantMapEntry {
 public:
@@ -990,7 +990,7 @@ public:
 	UInt8				Unk34;				// 34
 	UInt8				pad34[3];
 };
-assert(sizeof(NiD3DShaderConstantMapEntry) == 0x038);
+static_assert(sizeof(NiD3DShaderConstantMapEntry) == 0x038);
 
 class NiD3DShaderConstantMap {
 public:
@@ -1007,7 +1007,7 @@ public:
 	NiDX9RenderState*						RenderState;		// 30
 
 };
-assert(sizeof(NiD3DShaderConstantMap) == 0x034);
+static_assert(sizeof(NiD3DShaderConstantMap) == 0x034);
 
 class NiD3DShaderDeclaration : public NiObject {
 public:
@@ -1021,7 +1021,7 @@ public:
 	UInt32						Unk024;			// 024
 	UInt32						Unk028;			// 028
 };
-assert(sizeof(NiD3DShaderDeclaration) == 0x02C);
+static_assert(sizeof(NiD3DShaderDeclaration) == 0x02C);
 
 class NiDX9ShaderDeclaration : public NiD3DShaderDeclaration {
 public:
@@ -1029,7 +1029,7 @@ public:
 	UInt32		Unk030;			// 030
 	UInt32		Unk034;			// 034
 };
-assert(sizeof(NiDX9ShaderDeclaration) == 0x038);
+static_assert(sizeof(NiDX9ShaderDeclaration) == 0x038);
 
 class NiD3DShaderProgram : public NiRefObject {
 public:
@@ -1049,7 +1049,7 @@ public:
 	NiDX9Renderer*			Renderer;			// 20
 	NiDX9RenderState*		RenderState;		// 24
 };
-assert(sizeof(NiD3DShaderProgram) == 0x028);
+static_assert(sizeof(NiD3DShaderProgram) == 0x028);
 
 class NiD3DVertexShader : public NiD3DShaderProgram {
 public:
@@ -1059,13 +1059,13 @@ public:
 	IDirect3DVertexShader9*			ShaderHandle;	// 30
 	IDirect3DVertexDeclaration9*	Declaration;	// 34
 };
-assert(sizeof(NiD3DVertexShader) == 0x038);
+static_assert(sizeof(NiD3DVertexShader) == 0x038);
 
 class NiD3DPixelShader : public NiD3DShaderProgram {
 public:
 	IDirect3DPixelShader9*			ShaderHandle;	// 28
 };
-assert(sizeof(NiD3DPixelShader) == 0x02C);
+static_assert(sizeof(NiD3DPixelShader) == 0x02C);
 
 class NiD3DPass {
 public:
@@ -1091,14 +1091,14 @@ public:
 	UInt8							pad[2];
 	UInt32							RefCount;					// 60
 };
-assert(sizeof(NiD3DPass) == 0x064);
+static_assert(sizeof(NiD3DPass) == 0x064);
 
 class NiShader : public NiRefObject {
 public:
 	char*		Name;					// 008
 	UInt32		Unk00C;					// 00C
 };
-assert(sizeof(NiShader) == 0x010);
+static_assert(sizeof(NiShader) == 0x010);
 
 class NiD3DShaderInterface : public NiShader {
 public:
@@ -1109,7 +1109,7 @@ public:
 	UInt8				Unk01D;			// 01D
 	UInt8				pad[2];
 };
-assert(sizeof(NiD3DShaderInterface) == 0x020);
+static_assert(sizeof(NiD3DShaderInterface) == 0x020);
 
 class NiD3DShader : public NiD3DShaderInterface {
 public:
@@ -1126,7 +1126,7 @@ public:
 	NiTArray<NiD3DPass*>	Passes;				// 040
 	UInt32					Unk050[8];			// 050
 };
-assert(sizeof(NiD3DShader) == 0x70);
+static_assert(sizeof(NiD3DShader) == 0x70);
 
 class BSShader : public NiD3DShader {
 public:
@@ -1134,7 +1134,7 @@ public:
 	UInt32		Unk074;			// 074
 	UInt32		Unk078;			// 078
 };
-assert(sizeof(BSShader) == 0x7C);
+static_assert(sizeof(BSShader) == 0x7C);
 
 class GeometryDecalShader : public BSShader {
 public:
@@ -1143,7 +1143,7 @@ public:
 	NiD3DPixelShader*	Pixel[2];		// 08C
 	UInt32				Unk104[3];		// 094
 };
-assert(sizeof(GeometryDecalShader) == 0x0A0);
+static_assert(sizeof(GeometryDecalShader) == 0x0A0);
 
 class WaterShader : public BSShader {
 public:
@@ -1152,7 +1152,7 @@ public:
 	NiD3DPixelShader*	Pixel[16];		// 0C4
 	UInt32				Unk104[5];		// 104
 };
-assert(sizeof(WaterShader) == 0x118);
+static_assert(sizeof(WaterShader) == 0x118);
 
 class TallGrassShader : public BSShader {
 public:
@@ -1167,7 +1167,7 @@ public:
 	UInt16				pad160;				// 162
 	UInt32				Unk164[12];			// 164
 };
-assert(sizeof(TallGrassShader) == 0x194);
+static_assert(sizeof(TallGrassShader) == 0x194);
 
 class BSImageSpaceShader : public BSShader {
 public:
@@ -1177,7 +1177,7 @@ public:
 	UInt32		Unk088;		// 088
 	UInt32		Unk08C;		// 08C
 };
-assert(sizeof(BSImageSpaceShader) == 0x90);
+static_assert(sizeof(BSImageSpaceShader) == 0x90);
 
 class WaterShaderDisplacement : public BSImageSpaceShader {
 public:
@@ -1186,7 +1186,7 @@ public:
 	NiD3DPixelShader*	Pixel[8];		// 0D4
 	UInt32				Unk0F4[13];		// 0F4
 };
-assert(sizeof(WaterShaderDisplacement) == 0x128);
+static_assert(sizeof(WaterShaderDisplacement) == 0x128);
 
 class WaterShaderHeightMap : public BSImageSpaceShader {
 public:
@@ -1216,7 +1216,7 @@ public:
 	UInt32				Unk104;				// 104
 	UInt32				Unk108;				// 108
 };
-assert(sizeof(WaterShaderHeightMap) == 0x10C);
+static_assert(sizeof(WaterShaderHeightMap) == 0x10C);
 
 class HDRShader : public BSImageSpaceShader {
 public:
@@ -1226,7 +1226,7 @@ public:
 	UInt32				Unk0D4[13];		// 0D4
 	UInt32				Unk108[7];		// 108
 };
-assert(sizeof(HDRShader) == 0x124);
+static_assert(sizeof(HDRShader) == 0x124);
 
 class SpeedTreeLeafShader : public BSShader {
 public:
@@ -1235,7 +1235,7 @@ public:
 	NiD3DPixelShader*	Pixel[2];		// 38C
 	UInt32				Unk394;			// 394
 };
-assert(sizeof(SpeedTreeLeafShader) == 0x398);
+static_assert(sizeof(SpeedTreeLeafShader) == 0x398);
 
 class ShadowLightShader : public BSShader {
 public:
@@ -1248,21 +1248,21 @@ public:
 	NiD3DShaderConstantMap* PixelConstantMapSLS2;	// 094
 	NiD3DShaderConstantMap* VertexConstantMapSLS2;	// 098
 };
-assert(sizeof(ShadowLightShader) == 0x09C);
+static_assert(sizeof(ShadowLightShader) == 0x09C);
 
 class ParallaxShader : public ShadowLightShader {
 public:
 	NiD3DVertexShader*	Vertex[36];		// 09C
 	NiD3DPixelShader*	Pixel[30];		// 12C
 };
-assert(sizeof(ParallaxShader) == 0x1A4);
+static_assert(sizeof(ParallaxShader) == 0x1A4);
 
 class SkinShader : public ShadowLightShader {
 public:
 	NiD3DVertexShader*	Vertex[20];		// 09C
 	NiD3DPixelShader*	Pixel[10];		// 0EC
 };
-assert(sizeof(SkinShader) == 0x114);
+static_assert(sizeof(SkinShader) == 0x114);
 
 
 class NightEyeShader : public BSImageSpaceShader {
@@ -1271,14 +1271,14 @@ public:
 	NiD3DPixelShader*	Pixel[1];		// 094
 	//Incomplete def.
 };
-assert(sizeof(NightEyeShader) == 0x098); //Not the real size
+static_assert(sizeof(NightEyeShader) == 0x098); //Not the real size
 
 class ShaderDefinition {
 public:
 	NiDX9ShaderDeclaration* ShaderDeclaration;
 	BSShader*				Shader;
 };
-assert(sizeof(ShaderDefinition) == 0x008);
+static_assert(sizeof(ShaderDefinition) == 0x008);
 
 class Ni2DBuffer : public NiObject {
 public:
@@ -1286,10 +1286,10 @@ public:
 	UInt32				height;	// 00C
 	NiDX92DBufferData*	data;	// 010
 };
-assert(sizeof(Ni2DBuffer) == 0x014);
+static_assert(sizeof(Ni2DBuffer) == 0x014);
 
 class NiDepthStencilBuffer : public Ni2DBuffer {};
-assert(sizeof(NiDepthStencilBuffer) == 0x014);
+static_assert(sizeof(NiDepthStencilBuffer) == 0x014);
 
 class NiDX92DBufferData : public NiRefObject {
 public:
@@ -1312,7 +1312,7 @@ public:
 	Ni2DBuffer*			ParentData;												// 08
 	IDirect3DSurface9*	Surface;												// 0C
 };
-assert(sizeof(NiDX92DBufferData) == 0x010);
+static_assert(sizeof(NiDX92DBufferData) == 0x010);
 
 class NiDX9ImplicitBufferData : public NiDX92DBufferData {
 public:
@@ -1320,13 +1320,13 @@ public:
 	D3DPRESENT_PARAMETERS	PresentParams;								// 14
 	IDirect3DDevice9*		Device;										// 4C
 };
-assert(sizeof(NiDX9ImplicitBufferData) == 0x050);
+static_assert(sizeof(NiDX9ImplicitBufferData) == 0x050);
 
 class NiDX9ImplicitDepthStencilBufferData : public NiDX92DBufferData { };
-assert(sizeof(NiDX9ImplicitDepthStencilBufferData) == 0x010);
+static_assert(sizeof(NiDX9ImplicitDepthStencilBufferData) == 0x010);
 
 class NiDX9TextureBufferData : public NiDX92DBufferData { };
-assert(sizeof(NiDX9TextureBufferData) == 0x010);
+static_assert(sizeof(NiDX9TextureBufferData) == 0x010);
 
 class NiRenderTargetGroup : public NiObject {
 public:
@@ -1351,7 +1351,7 @@ public:
 	NiDepthStencilBuffer*			DepthStencilBuffer;			// 1C
 	void*							RenderData;					// 20
 };
-assert(sizeof(NiRenderTargetGroup) == 0x024);
+static_assert(sizeof(NiRenderTargetGroup) == 0x024);
 
 class NiGeometryGroup {
 public:
@@ -1369,7 +1369,7 @@ public:
 	UInt32				m_uiRefCount;	// 04
 	IDirect3DDevice9*	device;			// 08
 };
-assert(sizeof(NiGeometryGroup) == 0x00C);
+static_assert(sizeof(NiGeometryGroup) == 0x00C);
 
 class NiDX9RenderState : public NiRefObject {
 public:
@@ -1471,8 +1471,8 @@ public:
 	UInt32							unk1000[(0x1018 - 0x1000) >> 2];// 1000
 	D3DCAPS9						Caps;							// 1018
 };
-assert(offsetof(NiDX9RenderState, Device) == 0x0FF8);
-assert(sizeof(NiDX9RenderState) == 0x1148);
+static_assert(offsetof(NiDX9RenderState, Device) == 0x0FF8);
+static_assert(sizeof(NiDX9RenderState) == 0x1148);
 
 class NiAccumulator : public NiObject {
 public:
@@ -1483,7 +1483,7 @@ public:
 
 	NiCamera*		camera;	// 08
 };
-assert(sizeof(NiAccumulator) == 0x00C);
+static_assert(sizeof(NiAccumulator) == 0x00C);
 
 class NiRenderer : public NiObject {
 public:
@@ -1599,7 +1599,7 @@ public:
 	UInt8					unk20D;							// 20D
 	UInt8					pad20E[2];						// 20E
 };
-assert(sizeof(NiRenderer) == 0x210);
+static_assert(sizeof(NiRenderer) == 0x210);
 
 class NiDX9Renderer : public NiRenderer {
 public:
@@ -1825,7 +1825,7 @@ public:
 	NiTArray<void*>						lostDeviceCallbacksRefcons;		// AC8
 	UInt32								padAD0[(0xB00 - 0xAD8) >> 2];	// AD8
 };
-assert(sizeof(NiDX9Renderer) == 0xB00);
+static_assert(sizeof(NiDX9Renderer) == 0xB00);
 
 class NiControllerSequence : public NiObject {
 public:
@@ -1888,10 +1888,10 @@ public:
 	NiAVObject*			 accumRoot;		// 060
 	NiStringPalette*	 unk064;		// 064
 };
-assert(sizeof(NiControllerSequence) == 0x068);
+static_assert(sizeof(NiControllerSequence) == 0x068);
 
 class NiAVObjectPalette : public NiObject { };
-assert(sizeof(NiAVObjectPalette) == 0x008);
+static_assert(sizeof(NiAVObjectPalette) == 0x008);
 
 class NiDefaultAVObjectPalette : public NiAVObjectPalette {
 public:
@@ -1899,7 +1899,7 @@ public:
 	UInt32						unk018;			// 018
 	NiNode*						niNode;			// 01C
 };
-assert(sizeof(NiDefaultAVObjectPalette) == 0x020);
+static_assert(sizeof(NiDefaultAVObjectPalette) == 0x020);
 
 class BSFadeNode : public NiNode {
 public:
@@ -1911,7 +1911,7 @@ public:
 	UInt8	MultType;		// 0EC
 	UInt8	unk0ED[3];		// 0ED
 };
-assert(sizeof(BSFadeNode) == 0x0F0);
+static_assert(sizeof(BSFadeNode) == 0x0F0);
 
 class BSRenderedTexture : public NiRefObject {
 public:
@@ -1919,7 +1919,7 @@ public:
 	UInt32				 unk008[5];			// 00C
 	NiRenderedTexture*	 RenderedTexture;	// 020
 };
-assert(sizeof(BSRenderedTexture) == 0x024);
+static_assert(sizeof(BSRenderedTexture) == 0x024);
 
 class NiAlphaProperty : public NiProperty {
 public:
@@ -1939,7 +1939,7 @@ public:
 	UInt8	alphaTestRef;	// 01A
 	UInt8	unk01B;			// 01B
 };
-assert(sizeof(NiAlphaProperty) == 0x01C);
+static_assert(sizeof(NiAlphaProperty) == 0x01C);
 
 class NiShadeProperty : public NiProperty {
 public:
@@ -1948,7 +1948,7 @@ public:
 	UInt16	flags;		// 018
 	UInt8	pad01A[2];	// 01A
 };
-assert(sizeof(NiShadeProperty) == 0x01C);
+static_assert(sizeof(NiShadeProperty) == 0x01C);
 
 class BSShaderProperty : public NiShadeProperty {
 public:
@@ -2029,7 +2029,7 @@ public:
 	NiTList<RenderPass>	unk58;					// 058
 	UInt32				unk068;					// 068
 };
-assert(sizeof(BSShaderProperty) == 0x06C);
+static_assert(sizeof(BSShaderProperty) == 0x06C);
 
 class BSShaderLightingProperty : public BSShaderProperty {
 public:
@@ -2040,7 +2040,7 @@ public:
 	float						unk094;		// 094
 	UInt32						refID;		// 098
 };
-assert(sizeof(BSShaderLightingProperty) == 0x09C);
+static_assert(sizeof(BSShaderLightingProperty) == 0x09C);
 
 class BSShaderPPLightingProperty : public BSShaderLightingProperty {
 public:
@@ -2095,7 +2095,7 @@ public:
 	float			refractionPower;		// 0E8
 	UInt32			refractionPeriod;		// 0EC
 };
-assert(sizeof(BSShaderPPLightingProperty) == 0x0F0);
+static_assert(sizeof(BSShaderPPLightingProperty) == 0x0F0);
 
 class SpeedTreeShaderLightingProperty : public BSShaderLightingProperty {
 public:
@@ -2121,7 +2121,7 @@ public:
 	UInt32		unk0A0;	// 0A0
 	Str0A4*		unk0A4;	// 0A4
 };
-assert(sizeof(SpeedTreeShaderLightingProperty) == 0x0A8);
+static_assert(sizeof(SpeedTreeShaderLightingProperty) == 0x0A8);
 
 class SpeedTreeLeafShaderProperty : public SpeedTreeShaderLightingProperty {
 public:
@@ -2142,7 +2142,7 @@ public:
 	UInt16		unk0AC;		// 0AC
 	UInt8		unk0AE[2];	// 0AE
 };
-assert(sizeof(SpeedTreeLeafShaderProperty) == 0x0B0);
+static_assert(sizeof(SpeedTreeLeafShaderProperty) == 0x0B0);
 
 class BSTreeModel : public NiRefObject {
 public:
@@ -2167,7 +2167,7 @@ public:
 	UInt32					Unk50;				// 50
 	UInt32					Unk54;				// 54
 };
-assert(sizeof(BSTreeModel) == 0x058);
+static_assert(sizeof(BSTreeModel) == 0x058);
 
 class BSTreeNode : public NiNode {
 public:
@@ -2177,7 +2177,7 @@ public:
 	UInt32				UnkE8;			// E8
 	float				UnkEC;			// EC
 };
-assert(sizeof(BSTreeNode) == 0x0F0);
+static_assert(sizeof(BSTreeNode) == 0x0F0);
 
 class ShadowSceneLight : public NiRefObject {
 public:
@@ -2222,7 +2222,7 @@ public:
 	UInt32										unk218;				// 218
 	UInt32										unk21C;				// 21C
 };
-assert(sizeof(ShadowSceneLight) == 0x220);
+static_assert(sizeof(ShadowSceneLight) == 0x220);
 
 class ShadowSceneNode : public NiNode {
 public:
@@ -2245,4 +2245,4 @@ public:
 	UInt8								unk12C;				// 12C
 	UInt8								pad12D[3];			// 12D
 };
-assert(sizeof(ShadowSceneNode) == 0x130);
+static_assert(sizeof(ShadowSceneNode) == 0x130);

--- a/TESReloaded/Framework/Skyrim/Defines.h
+++ b/TESReloaded/Framework/Skyrim/Defines.h
@@ -9,7 +9,7 @@
 static const char* IntroMovie = "";
 static const char* MainMenuMovie = "";
 static const char* MainMenuMusic = "";
-static char* TitleMenu = "Skyrim Reloaded - Settings";
+static const char* TitleMenu = "Skyrim Reloaded - Settings";
 
 // to review
 static const char* WeatherColorTypes[TESWeather::kNumColorTypes] = { "SkyUpper", "Fog", "CloudsLower", "Ambient", "Sunlight", "Sun", "Stars", "SkyLower", "Horizon", "CloudsUpper" };

--- a/TESReloaded/Framework/Skyrim/Framework.h
+++ b/TESReloaded/Framework/Skyrim/Framework.h
@@ -2,7 +2,6 @@
 #pragma warning (disable: 4244) //disable warning for possible loss of data in implicit cast between int, float and double
 
 #define DETOURS_INTERNAL
-#define assert(a) static_assert(a, "Assertion failed")
 #define DIRECTINPUT_VERSION 0x0800
 
 #include <windows.h>

--- a/TESReloaded/Framework/Skyrim/Game.h
+++ b/TESReloaded/Framework/Skyrim/Game.h
@@ -100,7 +100,7 @@ class TESLoadScreen;
 class TESEffectShader;
 class TESRegionDataManager;
 class TESPackageData;
-class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; assert(sizeof(TESChildCell) == 0x004);
+class TESChildCell { public: virtual TESObjectCELL* GetChildCell(); }; static_assert(sizeof(TESChildCell) == 0x004);
 class TESImageSpace;
 class TESImageSpaceModifier;
 class TESReputation;
@@ -551,7 +551,7 @@ public:
 	UInt32		typeID;		// ParamType
 	UInt32		isOptional;
 };
-assert(sizeof(CommandParam) == 0x00C);
+static_assert(sizeof(CommandParam) == 0x00C);
 
 struct CommandArgs {
 	CommandParam*	 paramInfo;		// 00
@@ -563,7 +563,7 @@ struct CommandArgs {
 	double*			 result;		// 18
 	UInt32*			 opcodeOffset;	// 1C
 };
-assert(sizeof(CommandArgs) == 0x020);
+static_assert(sizeof(CommandArgs) == 0x020);
 
 struct CommandInfo {
 	const char*		longName;		// 00
@@ -578,7 +578,7 @@ struct CommandInfo {
 	void*			eval;			// 20
 	UInt32			flags;			// 24
 };
-assert(sizeof(CommandInfo) == 0x028);
+static_assert(sizeof(CommandInfo) == 0x028);
 
 class CommandTable {
 public:
@@ -731,7 +731,7 @@ public:
 
 	Entry First;
 };
-assert(sizeof(TList<void>) == 0x008);
+static_assert(sizeof(TList<void>) == 0x008);
 
 template <class T>
 class TArray {
@@ -740,7 +740,7 @@ public:
 	UInt32	capacity;
 	UInt32	count;
 };
-assert(sizeof(TArray<void>) == 0x00C);
+static_assert(sizeof(TArray<void>) == 0x00C);
 
 class RGBA {
 public:
@@ -749,7 +749,7 @@ public:
 	UInt8	b;
 	UInt8	a;
 };
-assert(sizeof(RGBA) == 0x004);
+static_assert(sizeof(RGBA) == 0x004);
 
 class SimpleLock {
 public:
@@ -764,7 +764,7 @@ class BSIntrusiveRefCounted {
 public:
 	volatile UInt32		m_refCount;		// 00
 };
-assert(sizeof(BSIntrusiveRefCounted) == 0x04);
+static_assert(sizeof(BSIntrusiveRefCounted) == 0x04);
 
 template <typename T>
 class BSTEventSink {
@@ -772,7 +772,7 @@ public:
 	virtual ~BSTEventSink();
 	virtual	UInt32	ReceiveEvent(T* evn, void* dispatcher); // pure virtual	EventResult	ReceiveEvent(T * evn, EventDispatcher<T> * dispatcher);
 };
-assert(sizeof(BSTEventSink<void>) == 0x04);
+static_assert(sizeof(BSTEventSink<void>) == 0x04);
 
 template <typename T>
 class EventDispatcher {
@@ -784,7 +784,7 @@ public:
 	UInt8						stateFlag;			// 02C - some internal state changed while sending
 	UInt8						pad[3];
 };
-assert(sizeof(EventDispatcher<void>) == 0x30);
+static_assert(sizeof(EventDispatcher<void>) == 0x30);
 
 class BSString {
 public:
@@ -792,7 +792,7 @@ public:
 	UInt16		m_dataLen;  // 04
 	UInt16		m_bufLen;	// 06
 };
-assert(sizeof(BSString) == 0x008);
+static_assert(sizeof(BSString) == 0x008);
 
 class InputEvent {
 public:
@@ -813,7 +813,7 @@ public:
 	UInt32			eventType;	// 08
 	InputEvent*		next;		// 0C
 };
-assert(sizeof(InputEvent) == 0x10);
+static_assert(sizeof(InputEvent) == 0x10);
 
 class ButtonEvent : public InputEvent {
 public:
@@ -822,7 +822,7 @@ public:
 	UInt32			flags;		// 18 (00000038 when ALT is pressed, 0000001D when STRG is pressed)
 	float			timer;		// 1C (hold duration)
 };
-assert(sizeof(ButtonEvent) == 0x20);
+static_assert(sizeof(ButtonEvent) == 0x20);
 
 class PlayerInputHandler {
 public:
@@ -835,7 +835,7 @@ public:
 	UInt8		unk04;			// 04
 	UInt8		pad04[3];
 };
-assert(sizeof(PlayerInputHandler) == 0x08);
+static_assert(sizeof(PlayerInputHandler) == 0x08);
 
 class InputStringHolder {
 public:
@@ -946,7 +946,7 @@ public:
 	BSFixedString	localMapMoveMode;	// 198 "LocalMapMoveMode"
 	BSFixedString	itemZoom;			// 19C "Item Zoom"
 };
-assert(sizeof(InputStringHolder) == 0x1A0);
+static_assert(sizeof(InputStringHolder) == 0x1A0);
 
 class UIStringHolder {
 public:
@@ -1214,7 +1214,7 @@ public:
 
 	BSExtraData*	next;		// 04	
 };
-assert(sizeof(BSExtraData) == 0x08);
+static_assert(sizeof(BSExtraData) == 0x08);
 
 class InventoryChanges : public BSExtraData {
 public:
@@ -1237,7 +1237,7 @@ public:
 
 	Data*	data;			// 08
 };
-assert(sizeof(InventoryChanges) == 0x0C);
+static_assert(sizeof(InventoryChanges) == 0x0C);
 
 class ExtraDataList {
 public:
@@ -1254,7 +1254,7 @@ public:
 	BSExtraData*			m_data;				// 000
 	PresenceBitfield*		m_presenceBitfield;	// 004 - if a bit is set, then the extralist should contain that extradata - bits are numbered starting from the lsb
 };
-assert(sizeof(ExtraDataList) == 0x08);
+static_assert(sizeof(ExtraDataList) == 0x08);
 
 class MagicTarget {
 public:
@@ -1274,7 +1274,7 @@ public:
 	UInt32	unk04;		// 04
 	UInt32	unk08;		// 08
 };
-assert(sizeof(MagicTarget) == 0xC);
+static_assert(sizeof(MagicTarget) == 0xC);
 
 class BaseFormComponent {
 public:
@@ -1283,14 +1283,14 @@ public:
 	virtual void	ReleaseRefs();
 	virtual void	CopyFromBase(BaseFormComponent* rhs);
 };
-assert(sizeof(BaseFormComponent) == 0x04);
+static_assert(sizeof(BaseFormComponent) == 0x04);
 
 class TESDescription : public BaseFormComponent {
 public:
 	UInt32	unk04;	// 04
 	UInt32	unk08;	// 08 - init'd to FFFFFFFF
 };
-assert(sizeof(TESDescription) == 0x0C);
+static_assert(sizeof(TESDescription) == 0x0C);
 
 class TESModel : public BaseFormComponent {
 public:
@@ -1305,16 +1305,16 @@ public:
 	UInt8			unk12;	// 12
 	UInt8			unk13;	// 13
 };
-assert(sizeof(TESModel) == 0x14);
+static_assert(sizeof(TESModel) == 0x14);
 
 class TESTexture : public BaseFormComponent {
 public:
 	BSFixedString	ddsPath;		// 04
 };
-assert(sizeof(TESTexture) == 0x08);
+static_assert(sizeof(TESTexture) == 0x08);
 
 class TESIcon : public TESTexture {};
-assert(sizeof(TESIcon) == 0x08);
+static_assert(sizeof(TESIcon) == 0x08);
 
 class TESFullName : public BaseFormComponent {
 public:
@@ -1323,7 +1323,7 @@ public:
 
 	BSFixedString	name;	// 04
 };
-assert(sizeof(TESFullName) == 0x08);
+static_assert(sizeof(TESFullName) == 0x08);
 
 class TESEnchantableForm : public BaseFormComponent {
 public:
@@ -1333,19 +1333,19 @@ public:
 	UInt16				unk08;			// 08 - init'd to 3
 	UInt16				maxCharge;
 };
-assert(sizeof(TESEnchantableForm) == 0x0C);
+static_assert(sizeof(TESEnchantableForm) == 0x0C);
 
 class TESValueForm : public BaseFormComponent {
 public:
 	UInt32	value;
 };
-assert(sizeof(TESValueForm) == 0x008);
+static_assert(sizeof(TESValueForm) == 0x008);
 
 class TESWeightForm : public BaseFormComponent {
 public:
 	float	weight;
 };
-assert(sizeof(TESWeightForm) == 0x008);
+static_assert(sizeof(TESWeightForm) == 0x008);
 
 class TESAttackDamageForm : public BaseFormComponent {
 public:
@@ -1354,7 +1354,7 @@ public:
 	UInt16	attackDamage;	// 04
 	UInt8	pad06[2];		// 06
 };
-assert(sizeof(TESAttackDamageForm) == 0x8);
+static_assert(sizeof(TESAttackDamageForm) == 0x8);
 
 class BGSDestructibleObjectForm : public BaseFormComponent {
 public:
@@ -1371,7 +1371,7 @@ public:
 
 	Data*	data;	// 04
 };
-assert(sizeof(BGSDestructibleObjectForm) == 0x8);
+static_assert(sizeof(BGSDestructibleObjectForm) == 0x8);
 
 class BGSEquipType : public BaseFormComponent {
 public:
@@ -1380,33 +1380,33 @@ public:
 
 	BGSEquipType*	unk04;	// 04
 };
-assert(sizeof(BGSEquipType) == 0x8);
+static_assert(sizeof(BGSEquipType) == 0x8);
 
 class BGSPreloadable : public BaseFormComponent {
 public:
 	virtual void	Unk_04();	// pure virtual
 };
-assert(sizeof(BGSPreloadable) == 0x4);
+static_assert(sizeof(BGSPreloadable) == 0x4);
 
 class BGSMessageIcon : public BaseFormComponent {
 public:
 	TESIcon		icon;	// 04
 };
-assert(sizeof(BGSMessageIcon) == 0xC);
+static_assert(sizeof(BGSMessageIcon) == 0xC);
 
 class BGSPickupPutdownSounds : public BaseFormComponent {
 public:
 	BGSSoundDescriptorForm*		pickUp;		// 04
 	BGSSoundDescriptorForm*		putDown;	// 08
 };
-assert(sizeof(BGSPickupPutdownSounds) == 0xC);
+static_assert(sizeof(BGSPickupPutdownSounds) == 0xC);
 
 class BGSBlockBashData : public BaseFormComponent {
 public:
 	UInt32	unk04;	// 04
 	UInt32	unk08;	// 08
 };
-assert(sizeof(BGSBlockBashData) == 0xC);
+static_assert(sizeof(BGSBlockBashData) == 0xC);
 
 class BGSKeywordForm : public BaseFormComponent {
 public:
@@ -1416,7 +1416,7 @@ public:
 	BGSKeyword**	keywords;		// 04
 	UInt32			numKeywords;	// 08
 };
-assert(sizeof(BGSKeywordForm) == 0xC);
+static_assert(sizeof(BGSKeywordForm) == 0xC);
 
 class TESModelTextureSwap : public TESModel {
 public:
@@ -1430,7 +1430,7 @@ public:
 	SwapInfo*		swaps;	// 14
 	UInt32			count;		// 18
 };
-assert(sizeof(TESModelTextureSwap) == 0x1C);
+static_assert(sizeof(TESModelTextureSwap) == 0x1C);
 
 class TESForm : public BaseFormComponent {
 public:
@@ -1647,7 +1647,7 @@ public:
 	UInt8	formType;	// 12
 	UInt8	pad13;		// 13
 };
-assert(sizeof(TESForm) == 0x14);
+static_assert(sizeof(TESForm) == 0x14);
 
 class TESPackage : public TESForm {
 public:
@@ -1739,7 +1739,7 @@ public:
 	UInt32	unk78;			// 78
 	UInt32	unk7C;			// 7C - incremented in dtor
 };
-assert(sizeof(TESPackage) == 0x80);
+static_assert(sizeof(TESPackage) == 0x80);
 
 class TESWeather : public TESForm {
 public:
@@ -1874,14 +1874,14 @@ public:
 	void*			particleShader;					// 758 BGSShaderParticleGeometryData*
 	void*			referenceEffect;				// 75C BGSReferenceEffect*
 };
-assert(sizeof(TESWeather) == 0x760);
+static_assert(sizeof(TESWeather) == 0x760);
 
 class TESWeatherEx : public TESWeather {
 public:
 	ColorData	colorsb[kNumColorTypes];
 	char		EditorName[40];
 };
-assert(sizeof(TESWeatherEx) == 0x898);
+static_assert(sizeof(TESWeatherEx) == 0x898);
 
 class TESIdleForm : public TESForm {
 public:
@@ -1916,7 +1916,7 @@ public:
 	BSFixedString		animationEvent;	// 30
 	BSString			editorId;		// 34
 };
-assert(sizeof(TESIdleForm) == 0x3C);
+static_assert(sizeof(TESIdleForm) == 0x3C);
 
 class TESClimate : public TESForm {
 public:
@@ -1937,7 +1937,7 @@ public:
 	UInt8		moonInfo;		// 45
 	UInt8		pad46[2];		// 46
 };
-assert(sizeof(TESClimate) == 0x48);
+static_assert(sizeof(TESClimate) == 0x48);
 
 class TESWaterForm : public TESForm {
 public:
@@ -2068,7 +2068,7 @@ public:
 	Data1C8				unk1BC;		// 1BC
 	Data1C8				unk1C8;		// 1C8
 };
-assert(sizeof(TESWaterForm) == 0x1D4);
+static_assert(sizeof(TESWaterForm) == 0x1D4);
 
 class TESWorldSpace : public TESForm {
 public:
@@ -2136,7 +2136,7 @@ public:
 	UInt32					unk16C;		// 16C
 	UInt32					unk170;		// 170
 };
-assert(sizeof(TESWorldSpace) == 0x174);
+static_assert(sizeof(TESWorldSpace) == 0x174);
 
 class TESGlobal : public TESForm {
 public:
@@ -2145,7 +2145,7 @@ public:
 	UInt8		pad[3];	// 1D
 	float		data;	// 20
 };
-assert(sizeof(TESGlobal) == 0x24);
+static_assert(sizeof(TESGlobal) == 0x24);
 
 class TESRegion : public TESForm {
 public:
@@ -2155,13 +2155,13 @@ public:
 	TESWeather*		weather;		// 20
 	UInt32			unk24[3];		// 24
 };
-assert(sizeof(TESRegion) == 0x30);
+static_assert(sizeof(TESRegion) == 0x30);
 
 class TESRegionEx : public TESRegion {
 public:
 	char		EditorName[40];
 };
-assert(sizeof(TESRegionEx) == 0x058);
+static_assert(sizeof(TESRegionEx) == 0x058);
 
 class BGSStoryManagerTreeForm : public TESForm {
 public:
@@ -2236,7 +2236,7 @@ public:
 	UInt32				unk148;		// 148
 	TArray<UInt32>		unk14C;		// 14C
 };
-assert(sizeof(TESQuest) == 0x158);
+static_assert(sizeof(TESQuest) == 0x158);
 
 class TESObject : public TESForm {
 public:
@@ -2255,7 +2255,7 @@ public:
 	virtual UInt32	Unk_45();
 	virtual void*	Unk_46();
 };
-assert(sizeof(TESObject) == 0x14);
+static_assert(sizeof(TESObject) == 0x14);
 
 class ActorValueInfo : public TESForm {
 public:
@@ -2284,7 +2284,7 @@ public:
 	BGSSkillPerkTreeNode*	perkTree;			// BC - BGSSkillPerkTreeNode
 	UInt8					padC0[8];	// C0 - ? not initialized
 };
-assert(sizeof(ActorValueInfo) == 0xC8);
+static_assert(sizeof(ActorValueInfo) == 0xC8);
 
 class TESBoundObject : public TESObject {
 public:
@@ -2309,10 +2309,10 @@ public:
 	Bound	bounds;		// 14
 	Bound	bounds2;	// 1A
 };
-assert(sizeof(TESBoundObject) == 0x20);
+static_assert(sizeof(TESBoundObject) == 0x20);
 
 class TESBoundAnimObject : public TESBoundObject {};
-assert(sizeof(TESBoundAnimObject) == 0x20);
+static_assert(sizeof(TESBoundAnimObject) == 0x20);
 
 class TESSound : public TESBoundAnimObject {
 public:
@@ -2321,7 +2321,7 @@ public:
 
 	BGSSoundDescriptorForm* descriptor;	// 20
 };
-assert(sizeof(TESSound) == 0x24);
+static_assert(sizeof(TESSound) == 0x24);
 
 class TESObjectLIGH : public TESBoundAnimObject {
 public:
@@ -2358,7 +2358,7 @@ public:
 	UInt32						unkA4;			// A4
 	DataA8						unkA8;			// A8
 };
-assert(sizeof(TESObjectLIGH) == 0xB4);
+static_assert(sizeof(TESObjectLIGH) == 0xB4);
 
 class TESObjectWEAP : public TESBoundObject {
 public:
@@ -2466,7 +2466,7 @@ public:
 	BSFixedString				embeddedNode;	// 12C
 	UInt32						pad130;			// 130
 };
-assert(sizeof(TESObjectWEAP) == 0x134);
+static_assert(sizeof(TESObjectWEAP) == 0x134);
 
 class BGSPerkEntry {
 public:
@@ -2476,7 +2476,7 @@ public:
 	UInt8	priority;		// 05
 	UInt16	type;			// 06
 };
-assert(sizeof(BGSPerkEntry) == 0x08);
+static_assert(sizeof(BGSPerkEntry) == 0x08);
 
 class Condition {
 public:
@@ -2516,7 +2516,7 @@ public:
 	UInt8		comparisonType;			// 1C
 	UInt8		referenceType;			// 1D
 };
-assert(sizeof(Condition) == 0x20);
+static_assert(sizeof(Condition) == 0x20);
 
 class BGSPerk : public TESForm {
 public:
@@ -2539,7 +2539,7 @@ public:
 	TArray<BGSPerkEntry*>	perkEntries;	// 3C
 	BGSPerk*				nextPerk;		// 48
 };
-assert(sizeof(BGSPerk) == 0x4C);
+static_assert(sizeof(BGSPerk) == 0x4C);
 
 class TESObjectREFRData {
 public:
@@ -2554,7 +2554,7 @@ public:
 	NiNode* node;			// 20
 	// ... probably more
 };
-assert(sizeof(TESObjectREFRData) == 0x24);
+static_assert(sizeof(TESObjectREFRData) == 0x24);
 
 class TESObjectCELL : public TESForm {
 public:
@@ -2637,7 +2637,7 @@ public:
 	UInt32					unk88;			// 88
 	BGSLightingTemplate*	lightingTemplate;	// 8C
 };
-assert(sizeof(TESObjectCELL) == 0x90);
+static_assert(sizeof(TESObjectCELL) == 0x90);
 
 class TESObjectREFR : public TESForm {
 public:
@@ -2754,7 +2754,7 @@ public:
 	ExtraDataList		extraDataList;		// 48
 	UInt32				unk50;				// flags?
 };
-assert(sizeof(TESObjectREFR) == 0x54);
+static_assert(sizeof(TESObjectREFR) == 0x54);
 
 class ActorValuesOwner {
 public:
@@ -2768,7 +2768,7 @@ public:
 	virtual void	SetCurrent(UInt32 arg0, float arg1);
 	virtual bool	Unk_08();
 };
-assert(sizeof(ActorValuesOwner) == 0x4);
+static_assert(sizeof(ActorValuesOwner) == 0x4);
 
 class ActorState {
 public:
@@ -2787,7 +2787,7 @@ public:
 
 	bool IsWeaponOut() { return (flags08 >> 5 & 7) >= 3; }
 };
-assert(sizeof(ActorState) == 0x0C);
+static_assert(sizeof(ActorState) == 0x0C);
 
 class HighProcess {
 public:
@@ -2913,7 +2913,7 @@ public:
 	float			actorAlpha;	// 1B4
 	// More?...
 };
-assert(sizeof(HighProcess) == 0x1B8);
+static_assert(sizeof(HighProcess) == 0x1B8);
 
 class ActorProcessManager {
 public:
@@ -2946,7 +2946,7 @@ public:
 	SInt8				unk9B;						// 9B
 	UInt8				unk9C[(0xA0 - 0x9C)];		// 9C
 };
-assert(sizeof(ActorProcessManager) == 0xA0);
+static_assert(sizeof(ActorProcessManager) == 0xA0);
 
 class EquipManager {
 public:
@@ -2957,7 +2957,7 @@ public:
 	UInt8	Initialized;	// 00
 	UInt8	pad00[3];
 };
-assert(sizeof(EquipManager) == 0x04);
+static_assert(sizeof(EquipManager) == 0x04);
 
 class Actor : public TESObjectREFR {
 public:
@@ -3121,10 +3121,10 @@ public:
 	UInt32					flags138;						// 138 Burgling house: flags138 >> 12 & 1
 	UInt32					unk13C[(0x19C - 0x13C) >> 2];
 };
-assert(sizeof(Actor) == 0x19C);
+static_assert(sizeof(Actor) == 0x19C);
 
 class Character : public Actor {};
-assert(sizeof(Character) == 0x19C);
+static_assert(sizeof(Character) == 0x19C);
 
 class TESCameraState {
 public:
@@ -3158,7 +3158,7 @@ public:
 	PlayerCamera*			camera;			// 08
 	UInt32					stateId;		// 0C
 };
-assert(sizeof(TESCameraState) == 0x010);
+static_assert(sizeof(TESCameraState) == 0x010);
 
 class DragonCameraState : public TESCameraState {
 public:
@@ -3175,7 +3175,7 @@ public:
 	UInt8					padBB;
 	// More
 };
-assert(sizeof(DragonCameraState) == 0x0BC);
+static_assert(sizeof(DragonCameraState) == 0x0BC);
 
 class HorseCameraState : public TESCameraState {
 public:
@@ -3192,19 +3192,19 @@ public:
 	UInt8					padBB;
 	// More
 };
-assert(sizeof(HorseCameraState) == 0x0BC);
+static_assert(sizeof(HorseCameraState) == 0x0BC);
 
 class TweenMenuCameraState : public TESCameraState {
 public:
 	UInt32	unk10[0x0C];	// 10
 };
-assert(sizeof(TweenMenuCameraState) == 0x040);
+static_assert(sizeof(TweenMenuCameraState) == 0x040);
 
 class VATSCameraState : public TESCameraState {
 public:
 	UInt32	unk10[0x03];	// 10
 };
-assert(sizeof(VATSCameraState) == 0x01C);
+static_assert(sizeof(VATSCameraState) == 0x01C);
 
 class FreeCameraState : public TESCameraState {
 public:
@@ -3215,10 +3215,10 @@ public:
 	UInt8					unk36;				// 36
 	UInt8					unk37;				// 37
 };
-assert(sizeof(FreeCameraState) == 0x038);
+static_assert(sizeof(FreeCameraState) == 0x038);
 
 class AutoVanityState : public TESCameraState { };
-assert(sizeof(AutoVanityState) == 0x010);
+static_assert(sizeof(AutoVanityState) == 0x010);
 
 class FurnitureCameraState : public TESCameraState {
 public:
@@ -3234,13 +3234,13 @@ public:
 	UInt8	unk2E;	// 2E
 	UInt8	pad2F;	// 2F
 };
-assert(sizeof(FurnitureCameraState) == 0x030);
+static_assert(sizeof(FurnitureCameraState) == 0x030);
 
 class IronSightsState : public TESCameraState {
 public:
 	UInt32	unk10;	// 10
 };
-assert(sizeof(IronSightsState) == 0x014);
+static_assert(sizeof(IronSightsState) == 0x014);
 
 class FirstPersonState : public TESCameraState {
 public:
@@ -3255,7 +3255,7 @@ public:
 	UInt8					pad3D;				// 3D
 	UInt16					pad3E;				// 3E
 };
-assert(sizeof(FirstPersonState) == 0x040);
+static_assert(sizeof(FirstPersonState) == 0x040);
 
 class ThirdPersonState : public TESCameraState {
 public:
@@ -3312,7 +3312,7 @@ public:
 	UInt8					TogglePOV;					// BA
 	UInt8					padBA;
 };
-assert(sizeof(ThirdPersonState) == 0xBC);
+static_assert(sizeof(ThirdPersonState) == 0xBC);
 
 class BleedoutCameraState : public TESCameraState {
 public:
@@ -3329,7 +3329,7 @@ public:
 	UInt8					padBB;
 	// More
 };
-assert(sizeof(BleedoutCameraState) == 0xBC);
+static_assert(sizeof(BleedoutCameraState) == 0xBC);
 
 class PlayerCameraTransitionState : public TESCameraState {
 public:
@@ -3338,7 +3338,7 @@ public:
 	UInt8	unk25;			// 25
 	UInt16	pad26;
 };
-assert(sizeof(PlayerCameraTransitionState) == 0x28);
+static_assert(sizeof(PlayerCameraTransitionState) == 0x28);
 
 class TESCamera {
 public:
@@ -3355,7 +3355,7 @@ public:
 	UInt8			unk24;			// 24
 	UInt8			pad24[3];
 };
-assert(sizeof(TESCamera) == 0x28);
+static_assert(sizeof(TESCamera) == 0x28);
 
 class PlayerCamera : public TESCamera {
 public:	
@@ -3393,7 +3393,7 @@ public:
 	UInt8							unkD5;										// D5
 	UInt8							padD5[2];
 };
-assert(sizeof(PlayerCamera) == 0xD8);
+static_assert(sizeof(PlayerCamera) == 0xD8);
 
 class PlayerSkills {
 public:
@@ -3418,7 +3418,7 @@ public:
 
 	StatData* data;		// 00
 };
-assert(sizeof(PlayerSkills) == 0x04);
+static_assert(sizeof(PlayerSkills) == 0x04);
 
 class PlayerCharacter : public Character {
 public:
@@ -3484,7 +3484,7 @@ public:
 	UInt8				unk727;							// 727
 	UInt32				unk728;							// 728
 };
-assert(sizeof(PlayerCharacter) == 0x72C);
+static_assert(sizeof(PlayerCharacter) == 0x72C);
 
 class PlayerControls {
 public:
@@ -3553,7 +3553,7 @@ public:
 	UInt8				unk15C;					// 15C
 	UInt8				pad15C[3];
 };
-assert(sizeof(PlayerControls) == 0x160);
+static_assert(sizeof(PlayerControls) == 0x160);
 
 class BSInputDevice {
 public:
@@ -3574,7 +3574,7 @@ public:
 	UInt32			unk008;							// 08
 	UInt32			unk00C;							// 0C	
 };
-assert(sizeof(BSInputDevice) == 0x10);
+static_assert(sizeof(BSInputDevice) == 0x10);
 
 class BSWin32KeyboardDevice : public BSInputDevice {
 public:
@@ -3588,7 +3588,7 @@ public:
 	UInt8			PreviousKeyState[0x100];		// F4
 	UInt8			CurrentKeyState[0x100];			// 1F4
 };
-assert(sizeof(BSWin32KeyboardDevice) == 0x2F4);
+static_assert(sizeof(BSWin32KeyboardDevice) == 0x2F4);
 
 class BSWin32MouseDevice : public BSInputDevice {
 public:
@@ -3604,10 +3604,10 @@ public:
 	DIMOUSESTATE2	CurrentMouseState;				// 44
 	UInt32			unk058;							// 58
 };
-assert(sizeof(BSWin32MouseDevice) == 0x5C);
+static_assert(sizeof(BSWin32MouseDevice) == 0x5C);
 
 class BSWin32GamepadDevice : public BSInputDevice {};
-assert(sizeof(BSWin32MouseDevice) == 0x5C);
+static_assert(sizeof(BSWin32MouseDevice) == 0x5C);
 
 class InputEventDispatcher : public EventDispatcher<InputEvent> {
 public:
@@ -3616,7 +3616,7 @@ public:
 	BSWin32MouseDevice*		mouse;		// 038
 	BSWin32GamepadDevice*	gamepad;	// 03C
 };
-assert(sizeof(InputEventDispatcher) == 0x040);
+static_assert(sizeof(InputEventDispatcher) == 0x040);
 
 class SkyObject {
 public:
@@ -3627,7 +3627,7 @@ public:
 
 	NiNode* RootNode;		// 04
 };
-assert(sizeof(SkyObject) == 0x08);
+static_assert(sizeof(SkyObject) == 0x08);
 
 class Atmosphere : public SkyObject {
 public:
@@ -3639,14 +3639,14 @@ public:
 	UInt32	unk14;	// 14
 	UInt32	unk18;	// 18
 };
-assert(sizeof(Atmosphere) == 0x1C);
+static_assert(sizeof(Atmosphere) == 0x1C);
 
 class Stars : public SkyObject {
 public:
 	UInt32	unk08;	// 08
 	UInt32	unk0C;	// 0C
 };
-assert(sizeof(Stars) == 0x10);
+static_assert(sizeof(Stars) == 0x10);
 
 class Sun : public SkyObject {
 public:
@@ -3662,13 +3662,13 @@ public:
 	UInt8		pad29[3];	// 29
 	UInt32		unk2C;	// 2C - BSShaderAccumulator
 };
-assert(sizeof(Sun) == 0x30);
+static_assert(sizeof(Sun) == 0x30);
 
 class Clouds : public SkyObject {
 public:
 	UInt32	unk08[(0x38C - 0x08) >> 2];		// 08
 };
-assert(sizeof(Clouds) == 0x38C);
+static_assert(sizeof(Clouds) == 0x38C);
 
 class Moon : public SkyObject {
 public:
@@ -3695,7 +3695,7 @@ public:
 	UInt32	unk58;		// 58
 	UInt32	unk5C[(0x7C - 0x5C) >> 2];
 };
-assert(sizeof(Moon) == 0x7C);
+static_assert(sizeof(Moon) == 0x7C);
 
 class Precipitation : public SkyObject {
 public:
@@ -3705,7 +3705,7 @@ public:
 	float	unk14;	// 14
 	float	unk18;	// 18
 };
-assert(sizeof(Precipitation) == 0x1C);
+static_assert(sizeof(Precipitation) == 0x1C);
 
 class Sky {
 public:
@@ -3764,7 +3764,7 @@ public:
 	void*			skyEffectController;			// 210
 	UInt32			unk214[(0x238 - 0x214) >> 2];	// 214
 };
-assert(sizeof(Sky) == 0x238);
+static_assert(sizeof(Sky) == 0x238);
 
 class GridArray {
 public:
@@ -3779,7 +3779,7 @@ public:
 	virtual void Fn_08();
 	virtual void Fn_09();
 };
-assert(sizeof(GridArray) == 0x04);
+static_assert(sizeof(GridArray) == 0x04);
 
 class GridCellArray : public GridArray {
 public:
@@ -3793,7 +3793,7 @@ public:
 	UInt8			unk20;		// 20
 	UInt8			pad20[3];
 };
-assert(sizeof(GridCellArray) == 0x24);
+static_assert(sizeof(GridCellArray) == 0x24);
 
 class TES {
 public:
@@ -3868,7 +3868,7 @@ public:
 	UInt32				navMeshInfoMap;		// NavMeshInfoMap
 	void*				loadedAreaBound;	// E4 LoadedAreaBound*
 };
-assert(sizeof(TES) == 0xE8);
+static_assert(sizeof(TES) == 0xE8);
 
 class Menu { // Wrapper class for compatibility with OR/NVR
 public:
@@ -3884,7 +3884,7 @@ public:
 		kMenuType_Persuasion = 0x40A,
 	};
 };
-assert(sizeof(Menu) == 0x01);
+static_assert(sizeof(Menu) == 0x01);
 
 class IFormFactory {
 public:
@@ -3905,7 +3905,7 @@ public:
 	UInt32			loadedModCount;		// 08
 	ModInfo*		loadedMods[0xFF];	// 0C
 };
-assert(sizeof(ModList) == 0x408);
+static_assert(sizeof(ModList) == 0x408);
 
 class MainDataHandler {
 public:
@@ -4077,13 +4077,13 @@ public:
 	ModList								modList;			// 694
 	UInt32								moreunks[100];		// A9C
 };
-assert(sizeof(MainDataHandler) == 0xC2C);
+static_assert(sizeof(MainDataHandler) == 0xC2C);
 
 class SoundControl {
 public:
 	void		Play(TESSound* Sound) {}
 };
-assert(sizeof(SoundControl) == 0x01);
+static_assert(sizeof(SoundControl) == 0x01);
 
 class Main {
 public:
@@ -4143,7 +4143,7 @@ public:
 	void*			cullingProcess2;	// F4 BSGeometryListCullingProcess*
 	UInt32			unkF8[12];			// F8
 };
-assert(sizeof(Main) == 0x128);
+static_assert(sizeof(Main) == 0x128);
 
 class MenuInterfaceManager {
 public:
@@ -4196,7 +4196,7 @@ public:
 	bool					unk_119;						// 119 (= 0)
 	char					pad[2];
 };
-assert(sizeof(MenuInterfaceManager) == 0x11C);
+static_assert(sizeof(MenuInterfaceManager) == 0x11C);
 
 class TimeGlobals {
 public:
@@ -4210,13 +4210,13 @@ public:
 
 	static float GetGameTime() { TimeGlobals* Globals = (TimeGlobals*)0x012E5690; return Globals->GameHour->data * 60.0f * 60.0f; }
 };
-assert(sizeof(TimeGlobals) == 0x1C); // Static class, size could be larger
+static_assert(sizeof(TimeGlobals) == 0x1C); // Static class, size could be larger
 
 class QueuedModelLoader {
 public:
 	UInt32	Unk000[32]; // LockFreeMaps and other
 };
-assert(sizeof(QueuedModelLoader) == 0x80);
+static_assert(sizeof(QueuedModelLoader) == 0x80);
 
 class GameSetting {
 public:
@@ -4228,7 +4228,7 @@ public:
 	};
 	char*		Name;
 };
-assert(sizeof(GameSetting) == 0x0C);
+static_assert(sizeof(GameSetting) == 0x0C);
 
 class VMValue {
 public:
@@ -4269,7 +4269,7 @@ public:
 		BSFixedString	s;
 	} data;			// 04
 };
-assert(sizeof(VMValue) == 0x08);
+static_assert(sizeof(VMValue) == 0x08);
 
 class VMArgList {
 public:
@@ -4288,7 +4288,7 @@ public:
 	UInt32		unk18;		// 18
 	UInt32		numArgs;	// 1C
 };
-assert(sizeof(VMState) == 0x20);
+static_assert(sizeof(VMState) == 0x20);
 
 class VMUnlinkedClassList {
 public:
@@ -4316,7 +4316,7 @@ public:
 	void*				unk40;		// 40
 	UInt32				unk44;		// 44
 };
-assert(sizeof(VMUnlinkedClassList) == 0x48);
+static_assert(sizeof(VMUnlinkedClassList) == 0x48);
 
 class VMClassRegistry {
 public:
@@ -4388,7 +4388,7 @@ public:
 	UInt32				waitingStacks[7];	// 49E4 typedef tHashSet<VMStackTableItem,UInt32> StackTableT;
 	UInt32				unk4A00[65];		// 4A00
 };
-assert(sizeof(VMClassRegistry) == 0x4B04);
+static_assert(sizeof(VMClassRegistry) == 0x4B04);
 
 class NativeFunction {
 public:
@@ -4457,7 +4457,7 @@ public:
 	BSFixedString			unk28;			// 28
 	void*					m_callback;		// 2C
 };
-assert(sizeof(NativeFunction) == 0x30);
+static_assert(sizeof(NativeFunction) == 0x30);
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
 class PapyrusFunction5 : public NativeFunction {

--- a/TESReloaded/Framework/Skyrim/GameHavok.h
+++ b/TESReloaded/Framework/Skyrim/GameHavok.h
@@ -16,26 +16,26 @@ public:
 	float	z;
 	float	w;
 };
-assert(sizeof(hkVector4) == 0x010);
+static_assert(sizeof(hkVector4) == 0x010);
 
 class hkQuaternion {
 public:
 	hkVector4	vec;
 };
-assert(sizeof(hkQuaternion) == 0x010);
+static_assert(sizeof(hkQuaternion) == 0x010);
 
 class hkBaseObject {
 public:
 	virtual void Destructor(bool FreeThis);
 };
-assert(sizeof(hkBaseObject) == 0x004);
+static_assert(sizeof(hkBaseObject) == 0x004);
 
 class hkRefObject : public hkBaseObject {
 public:
 	UInt16		sizeAndFlags;	// 04
 	UInt16		refCount;		// 06
 };
-assert(sizeof(hkRefObject) == 0x008);
+static_assert(sizeof(hkRefObject) == 0x008);
 
 class bhkRefObject : public NiObject {
 public:
@@ -44,4 +44,4 @@ public:
 
 	hkRefObject*	hkObject;	// 008
 };
-assert(sizeof(bhkRefObject) == 0x00C);
+static_assert(sizeof(bhkRefObject) == 0x00C);

--- a/TESReloaded/Framework/Skyrim/GameNi.h
+++ b/TESReloaded/Framework/Skyrim/GameNi.h
@@ -65,7 +65,7 @@ struct NiRTTI {
 	const char* name;
 	NiRTTI*		parent;
 };
-assert(sizeof(NiRTTI) == 0x008);
+static_assert(sizeof(NiRTTI) == 0x008);
 
 class BSFixedString {
 public:
@@ -79,14 +79,14 @@ public:
 	bool operator < (const BSFixedString& lhs) const { return m_data < lhs.m_data; }
 
 };
-assert(sizeof(BSFixedString) == 0x04);
+static_assert(sizeof(BSFixedString) == 0x04);
 
 class NiPoint2 {
 public:
 	float	x;
 	float	y;
 };
-assert(sizeof(NiPoint2) == 0x008);
+static_assert(sizeof(NiPoint2) == 0x008);
 
 class NiPoint3 {
 public:
@@ -112,7 +112,7 @@ public:
 		return D3DXVECTOR4(x, y, z, 1.0);
 	}
 };
-assert(sizeof(NiPoint3) == 0x00C);
+static_assert(sizeof(NiPoint3) == 0x00C);
 
 class NiVector4 {
 public:
@@ -135,7 +135,7 @@ public:
 	float z;
 	float w;
 };
-assert(sizeof(NiVector4) == 0x010);
+static_assert(sizeof(NiVector4) == 0x010);
 
 class NiMatrix33 {
 public:
@@ -206,7 +206,7 @@ public:
 
 	float data[3][3];
 };
-assert(sizeof(NiMatrix33) == 0x024);
+static_assert(sizeof(NiMatrix33) == 0x024);
 
 class NiTransform {
 public:
@@ -214,7 +214,7 @@ public:
 	NiPoint3	pos;		// 24
 	float		scale;		// 30
 };
-assert(sizeof(NiTransform) == 0x034);
+static_assert(sizeof(NiTransform) == 0x034);
 
 class NiPlane {
 public:
@@ -227,7 +227,7 @@ public:
 	NiPoint3	Normal;
 	float		Constant;
 };
-assert(sizeof(NiPlane) == 0x010);
+static_assert(sizeof(NiPlane) == 0x010);
 
 class NiBound {
 public:
@@ -242,7 +242,7 @@ public:
 	NiPoint3	Center;
 	float		Radius;
 };
-assert(sizeof(NiBound) == 0x010);
+static_assert(sizeof(NiBound) == 0x010);
 
 class NiFrustum {
 public:
@@ -255,7 +255,7 @@ public:
 	UInt8	Ortho;		// 18
 	UInt8	pad18[3];
 };
-assert(sizeof(NiFrustum) == 0x01C);
+static_assert(sizeof(NiFrustum) == 0x01C);
 
 class NiFrustumPlanes {
 public:
@@ -272,7 +272,7 @@ public:
 	NiPlane	CullingPlanes[MaxPlanes];	// 00
 	UInt32	ActivePlanes;				// 60
 };
-assert(sizeof(NiFrustumPlanes) == 0x064);
+static_assert(sizeof(NiFrustumPlanes) == 0x064);
 
 class NiViewport {
 public:
@@ -281,7 +281,7 @@ public:
 	float	t;
 	float	b;
 };
-assert(sizeof(NiViewport) == 0x010);
+static_assert(sizeof(NiViewport) == 0x010);
 
 class NiColor {
 public:
@@ -289,7 +289,7 @@ public:
 	float	g;
 	float	b;
 };
-assert(sizeof(NiColor) == 0x00C);
+static_assert(sizeof(NiColor) == 0x00C);
 
 class NiColorAlpha {
 public:
@@ -298,7 +298,7 @@ public:
 	float	b;
 	float	a;
 };
-assert(sizeof(NiColorAlpha) == 0x010);
+static_assert(sizeof(NiColorAlpha) == 0x010);
 
 template <typename T>
 class NiTList {
@@ -317,7 +317,7 @@ public:
 	Entry*	end;		// 008
 	UInt32	numItems;	// 00C
 };
-assert(sizeof(NiTList<void>) == 0x010);
+static_assert(sizeof(NiTList<void>) == 0x010);
 
 template <typename TKey, typename TData>
 class NiTMap {
@@ -339,7 +339,7 @@ public:
 	Entry**			m_buckets;		// 8
 	UInt32			m_numItems;		// C
 };
-assert(sizeof(NiTMap<void, void>) == 0x010);
+static_assert(sizeof(NiTMap<void, void>) == 0x010);
 
 template <typename T>
 class NiTArray {
@@ -354,7 +354,7 @@ public:
 	UInt16	numObjs;		// 0C - init'd to 0
 	UInt16	growSize;		// 0E - init'd to size of preallocation
 };
-assert(sizeof(NiTArray<void>) == 0x010);
+static_assert(sizeof(NiTArray<void>) == 0x010);
 
 template <typename T>
 class NiTLargeArray {
@@ -366,7 +366,7 @@ public:
 	UInt32	numObjs;		// 10 - init'd to 0
 	UInt32	growSize;		// 14 - init'd to size of preallocation
 };
-assert(sizeof(NiTLargeArray<void>) == 0x018);
+static_assert(sizeof(NiTLargeArray<void>) == 0x018);
 
 class NiPixelFormat {
 public:
@@ -449,7 +449,7 @@ public:
 	UInt32			ExtraData;		// 10
 	NiComponentSpec	Components[4];	// 14
 };
-assert(sizeof(NiPixelFormat) == 0x044);
+static_assert(sizeof(NiPixelFormat) == 0x044);
 
 class NiRefObject {
 public:
@@ -462,7 +462,7 @@ public:
 
 	volatile SInt32	m_uiRefCount;	// 04
 };
-assert(sizeof(NiRefObject) == 0x08);
+static_assert(sizeof(NiRefObject) == 0x08);
 
 class NiObject : public NiRefObject {
 public:
@@ -498,13 +498,13 @@ public:
 	virtual void				 SetGroup(NiObjectGroup* group);
 	virtual UInt32				 Unk_20();
 };
-assert(sizeof(NiObject) == 0x08);
+static_assert(sizeof(NiObject) == 0x08);
 
 class NiExtraData : public NiObject {
 public:
 	char*	m_pcName;	// 08
 };
-assert(sizeof(NiExtraData) == 0x0C);
+static_assert(sizeof(NiExtraData) == 0x0C);
 
 class NiObjectNET : public NiObject {
 public:
@@ -519,7 +519,7 @@ public:
 	UInt16				m_extraDataLen;			// 14 max valid entry
 	UInt16				m_extraDataCapacity;	// 16 array len
 };
-assert(sizeof(NiObjectNET) == 0x18);
+static_assert(sizeof(NiObjectNET) == 0x18);
 
 class NiAVObject : public NiObjectNET {
 public:
@@ -594,7 +594,7 @@ public:
 	UInt8			unkA4;				// A4
 	UInt8			unkA5;				// A5 - bitfield
 };
-assert(sizeof(NiAVObject) == 0xA8);
+static_assert(sizeof(NiAVObject) == 0xA8);
 
 class NiNode : public NiAVObject {
 public:
@@ -612,7 +612,7 @@ public:
 
 	NiTArray<NiAVObject*>	m_children;	// A8
 };
-assert(sizeof(NiNode) == 0xB8);
+static_assert(sizeof(NiNode) == 0xB8);
 
 class NiCamera : public NiAVObject {
 public:
@@ -623,7 +623,7 @@ public:
 	NiViewport		ViewPort;			// 10C
 	float			LODAdjust;			// 11C
 };
-assert(sizeof(NiCamera) == 0x120);
+static_assert(sizeof(NiCamera) == 0x120);
 
 class SceneGraph : public NiNode {
 public:
@@ -639,13 +639,13 @@ public:
 	UInt32				unkD0;					// D0
 	UInt32				unkD4;					// D4
 };
-assert(sizeof(SceneGraph) == 0xD8);
+static_assert(sizeof(SceneGraph) == 0xD8);
 
 class NiLight : public NiAVObject {
 public:
 	UInt32		unkA8[11];	// A8
 };
-assert(sizeof(NiLight) == 0xD4);
+static_assert(sizeof(NiLight) == 0xD4);
 
 class NiPointLight : public NiLight {
 public:
@@ -653,7 +653,7 @@ public:
 	float		unkD8;	// D8
 	float		unkDC;	// DC
 };
-assert(sizeof(NiPointLight) == 0xE0);
+static_assert(sizeof(NiPointLight) == 0xE0);
 
 class NiVBChip {
 public:
@@ -666,7 +666,7 @@ public:
 	NiVBChip*				Next;		// 18
 	NiVBChip*				Prev;		// 1C
 };
-assert(sizeof(NiVBChip) == 0x020);
+static_assert(sizeof(NiVBChip) == 0x020);
 
 class NiGeometryBufferData {
 public:
@@ -691,7 +691,7 @@ public:
 	UInt16*							ArrayLengths;			// 48
 	UInt16*							IndexArray;				// 4C
 };
-assert(sizeof(NiGeometryBufferData) == 0x50);
+static_assert(sizeof(NiGeometryBufferData) == 0x50);
 
 class NiGeometryData : public NiObject {
 public:
@@ -721,7 +721,7 @@ public:
 	UInt8						hasGeoData;			// 046
 	UInt8						pad47;				// 047
 };
-assert(sizeof(NiGeometryData) == 0x48);
+static_assert(sizeof(NiGeometryData) == 0x48);
 
 class NiSkinPartition : public NiObject {
 public:
@@ -745,7 +745,7 @@ public:
 	UInt32		PartitionsCount;		// 08
 	Partition*	Partitions;				// 0C
 };
-assert(sizeof(NiSkinPartition) == 0x10);
+static_assert(sizeof(NiSkinPartition) == 0x10);
 
 class NiSkinData : public NiObject {
 public:
@@ -770,7 +770,7 @@ public:
 	UInt32				Bones;				// 44
 
 };
-assert(sizeof(NiSkinData) == 0x48);
+static_assert(sizeof(NiSkinData) == 0x48);
 
 class NiSkinInstance : public NiObject {
 public:
@@ -787,7 +787,7 @@ public:
 	UInt32				Unk30;					// 30
 	UInt32				Unk34;					// 34
 };
-assert(sizeof(NiSkinInstance) == 0x38);
+static_assert(sizeof(NiSkinInstance) == 0x38);
 
 class NiProperty : public NiObjectNET {
 public:
@@ -796,7 +796,7 @@ public:
 		kType_Lighting,
 	};
 };
-assert(sizeof(NiProperty) == 0x18);
+static_assert(sizeof(NiProperty) == 0x18);
 
 class NiGeometry : public NiAVObject {
 public:
@@ -807,7 +807,7 @@ public:
 	NiGeometryData*			geomData;			// 0B0
 	NiSkinInstance*			skinInstance;		// 0B4
 };
-assert(sizeof(NiGeometry) == 0x0B8);
+static_assert(sizeof(NiGeometry) == 0x0B8);
 
 class NiDX9TextureData : public NiObject {
 public:
@@ -826,7 +826,7 @@ public:
 	UInt16					textureType;// 6A
 	UInt32					unk6C;		// 6C
 };
-assert(sizeof(NiDX9TextureData) == 0x70);
+static_assert(sizeof(NiDX9TextureData) == 0x70);
 
 class NiTexture : public NiObject {
 public:
@@ -880,7 +880,7 @@ public:
 	NiTexture*			nextTex;		// 01C
 	NiTexture*			prevTex;		// 020
 };
-assert(sizeof(NiTexture) == 0x24);
+static_assert(sizeof(NiTexture) == 0x24);
 
 class NiSourceTexture : public NiTexture {
 public:
@@ -893,7 +893,7 @@ public:
 	UInt32			unk2C;							// 2C
 	UInt8			flags;							// 30
 };
-assert(sizeof(NiSourceTexture) == 0x34);
+static_assert(sizeof(NiSourceTexture) == 0x34);
 
 class NiRenderedTexture : public NiTexture {
 public:
@@ -908,7 +908,7 @@ public:
 	UInt32		unk34;		// 34
 	UInt32		unk38;		// 38
 };
-assert(sizeof(NiRenderedTexture) == 0x3C);
+static_assert(sizeof(NiRenderedTexture) == 0x3C);
 
 class NiD3DVertexShader {
 public:
@@ -928,7 +928,7 @@ public:
 	UInt8					Vector4Count;		// 32
 	UInt8					unk33;				// 33
 };
-assert(sizeof(NiD3DVertexShader) == 0x34);
+static_assert(sizeof(NiD3DVertexShader) == 0x34);
 
 class NiD3DPixelShader {
 public:
@@ -960,7 +960,7 @@ public:
 	UInt8					Vector4Count;		// 62
 	UInt8					unk63;				// 63
 };
-assert(sizeof(NiD3DPixelShader) == 0x64);
+static_assert(sizeof(NiD3DPixelShader) == 0x64);
 
 class BSShader : public NiRefObject {
 public:
@@ -997,7 +997,7 @@ public:
 	UInt32		unk4C;		// 4C
 	UInt32		unk50;		// 50
 };
-assert(sizeof(BSShader) == 0x54);
+static_assert(sizeof(BSShader) == 0x54);
 
 class WaterShader : public BSShader {
 public:
@@ -1008,7 +1008,7 @@ public:
 	UInt32				Unk64;		// 64
 	UInt32				Unk68;		// 68
 };
-assert(sizeof(WaterShader) == 0x6C);
+static_assert(sizeof(WaterShader) == 0x6C);
 
 class Ni2DBuffer : public NiObject {
 public:
@@ -1016,10 +1016,10 @@ public:
 	UInt32				height;	// 00C
 	NiDX92DBufferData*	data;	// 010
 };
-assert(sizeof(Ni2DBuffer) == 0x014);
+static_assert(sizeof(Ni2DBuffer) == 0x014);
 
 class NiDepthStencilBuffer : public Ni2DBuffer {};
-assert(sizeof(NiDepthStencilBuffer) == 0x014);
+static_assert(sizeof(NiDepthStencilBuffer) == 0x014);
 
 class NiDX92DBufferData : public NiRefObject {
 public:
@@ -1028,7 +1028,7 @@ public:
 	UInt32					unk10;			// 10
 	IDirect3DSurface9*		Surface;		// 14
 };
-assert(sizeof(NiDX92DBufferData) == 0x18);
+static_assert(sizeof(NiDX92DBufferData) == 0x18);
 
 class NiRenderTargetGroup : public NiObject {
 public:
@@ -1038,7 +1038,7 @@ public:
 	NiDepthStencilBuffer*			DepthStencilBuffer;			// 20
 	void*							RenderData;					// 24
 };
-assert(sizeof(NiRenderTargetGroup) == 0x28);
+static_assert(sizeof(NiRenderTargetGroup) == 0x28);
 
 class NiRenderer : public NiObject {
 public:
@@ -1053,7 +1053,7 @@ public:
 	void Clear(float* Rect, UInt32 Flags) { ThisCall(0x00CD5D00, this, Rect, Flags); }
 
 };
-assert(sizeof(NiRenderer) == 0x08);
+static_assert(sizeof(NiRenderer) == 0x08);
 
 class NiDX9Renderer : public NiRenderer {
 public:
@@ -1188,7 +1188,7 @@ public:
 	UInt32								unk878;							// 878
 	UInt32								unk87C;							// 87C
 };
-assert(sizeof(NiDX9Renderer) == 0x880);
+static_assert(sizeof(NiDX9Renderer) == 0x880);
 
 class BSRenderedTexture : public NiObject {
 public:
@@ -1203,10 +1203,10 @@ public:
 	UInt32					unk038;				// 038
 	UInt32					unk03C;				// 03C
 };
-assert(sizeof(BSRenderedTexture) == 0x40);
+static_assert(sizeof(BSRenderedTexture) == 0x40);
 
 class ShadowSceneNode : public NiNode {
 public:
 	UInt32					unk0B8[91];
 };
-assert(sizeof(ShadowSceneNode) == 0x224);
+static_assert(sizeof(ShadowSceneNode) == 0x224);

--- a/TESReloaded/Framework/Skyrim/GameNi.h
+++ b/TESReloaded/Framework/Skyrim/GameNi.h
@@ -139,14 +139,14 @@ static_assert(sizeof(NiVector4) == 0x010);
 
 class NiMatrix33 {
 public:
-	NiPoint3 NiMatrix33::operator * (const NiPoint3 pt) const {
+	NiPoint3 operator * (const NiPoint3 pt) const {
 		return {
 			data[0][0] * pt.x + data[0][1] * pt.y + data[0][2] * pt.z,
 			data[1][0] * pt.x + data[1][1] * pt.y + data[1][2] * pt.z,
 			data[2][0] * pt.x + data[2][1] * pt.y + data[2][2] * pt.z
 		};
 	}
-	NiMatrix33 NiMatrix33::operator * (const NiMatrix33 mat) const {
+	NiMatrix33 operator * (const NiMatrix33 mat) const {
 		NiMatrix33 prd;
 
 		prd.data[0][0] =


### PR DESCRIPTION
Removed assert redefinition to static_assert
Fixed all struct size asserts to use static_assert
This fixes the debug build failing, since tomlplusplus properly uses runtime asserts

Added f suffix to float literals
Fixed class member and operator definitions
Fixed strings not stored as const char*
