### PR TITLE
Adapt NVR to corrected linear space tonemapping

### DIFF
--- a/Extra/NewVegasReloaded.dll.defaults.toml
+++ b/Extra/NewVegasReloaded.dll.defaults.toml
@@ -116,15 +116,15 @@ CoeffSunR = 1.0
 Enabled = false
 
 [_Shaders.AmbientOcclusion.Exteriors]
-AngleBias = 0.0                         # Value to increase the contribution of closer samples for more detail in creases.
+AngleBias = 1.6                         # Value to increase the contribution of closer samples for more detail in creases.
 BlurDropThreshold = 8.0                 # Distance cutoff for areas that shouldn't be blurred together (edge aware denoise).
 BlurRadiusMultiplier = 2.0              # Blur radius to denoise AO.
-ClampStrength = 0.2                     # Lower limit to AO darkness (0 for pure black and 1 for pure white).
+ClampStrength = 0.25                     # Lower limit to AO darkness (0 for pure black and 1 for pure white).
 Enabled = true                          # Enable Ambient occlusion in exteriors.
 LumThreshold = 0.7                      # Treshold to reduce AO strength on bright surfaces.
 Range = 30.0                            # Distance for sampling. Larger values create a softer AO, smaller creates sharper details.
 Samples = 5                             # Not used (currently hardcoded).
-StrengthMultiplier = 2.0                # Global AO strength/darkness multiplier.
+StrengthMultiplier = 1.0                # Global AO strength/darkness multiplier.
 
 [_Shaders.AmbientOcclusion.Interiors]
 AngleBias = 0.0                         # Value to increase the contribution of closer samples for more detail in creases.
@@ -135,7 +135,7 @@ Enabled = true                          # Enable Ambient occlusion in exteriors.
 LumThreshold = 0.5                      # Treshold to reduce AO strength on bright surfaces.
 Range = 30.0                            # Distance for sampling. Larger values create a softer AO, smaller creates sharper details.
 Samples = 5                             # Not used (currently hardcoded).
-StrengthMultiplier = 2.0                # Global AO strength/darkness multiplier.
+StrengthMultiplier = 1.0                # Global AO strength/darkness multiplier.
 
 [_Shaders.AmbientOcclusion.Status]
 Enabled = true                          # Shadows based on object proximity/creases for more realistic light contribution.
@@ -179,8 +179,8 @@ Enabled = false                         # Increases the blurriness and light ble
 AspectRatio = 2.35                      # Letterbox/black bars effect. Use the value of Width/Height of the visible window (1 to disable).
 ChromaticAberration = 1.0               # Lens distortion effect that separates the red/green and blue channels slightly as a real lens would.
 FilmGrainAmount = 0.3                   # Animated cinema grain at 24fps like film.
-Mode = 2                                # Chose when the letterbox effect is activated 0: always, 1: not during dialog, 2: only during dialog.
-OverlayStrength = 0.2                   # Overlays the screen image onto itself to increase color intensity and contrast.
+Mode = 3                                # Chose when the letterbox effect is activated 0: always, 1: not during dialog, 2: only during dialog.
+OverlayStrength = 0.1                   # Overlays the screen image onto itself to increase color intensity and contrast.
 VignetteDarkness = 1.2                  # Darkening of the edges of the screen.
 VignetteRadius = 0.6                    # Distance to the center for the start of the Vignette effect.
 LetterBoxDepth = 0.0                    # Depth of the letter box bars
@@ -292,11 +292,11 @@ MaxDistance = 0
 Enabled = false                       # Not currently used. Replaces grass shaders and game options.  
 
 [_Shaders.GodRays.Main]
-DayMultiplier = 0.3                   # Strength of godrays during the day.
+DayMultiplier = 0.5                   # Strength of godrays during the day.
 LightShaftPasses = 8                  # Not used.
 Luminance = 0.9                       # Treshold for minimum luminosity of areas casting rays. Lower means more of the sky will cast rays.
 NightMultiplier = 1.0                 # Strength of godrays during the night.
-RayDensity = 0.3                      # Curve for reduction of the intensity of godrays near the sunglare.
+RayDensity = 0.5                      # Curve for reduction of the intensity of godrays near the sunglare.
 RayIntensity = 1.0                    # Multiplier for the intensity of the bright areas being blurred to create the rays.
 RayLength = 1.0                       # Multiplier for the length of rays.
 RayVisibility = 4.0                   # Exponent for the godrays contrast.
@@ -314,108 +314,108 @@ Saturate = 0.0                        # Influence of the coloring setting. 0: us
 Enabled = true                        # Screenspace godrays/volumetric rays.
 
 
-[_Shaders.HDR.Main]
+[_Shaders.Tonemapping.Main]
+TonemappingMode = 1                   # Tonemapping Algorithm -  0: None (vanilla), 1: VTLottes (default), 2:NVRLottes, 3:Reinhard, 4: Reinhard Jodie, 5: ACES Filmic, 6: ACES Fitted, 7:Uncharted 2, 8:Uchimura (GT), 9:AGX
+Exposure = 1.0                        # Scales the engine lighting strength/brightness range before tonemap, useful for HDR rendering
+Gamma = 2.2                           # Gamma modifier to be applied after tonemapping, delinearises output. If placed at 1.0, outputs at linear space for HDR (UI unaffected)
+Linearization = 2.2                   # Converts image to corrected linear space before tonemapping. 1.0 is non-linear, if so place Gamma at 1.0 as well
+SkyMultiplier = 1.0                   # Scales the brightness of the sky/sun textures. Requires Sky shader enabled
+WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers (brightness, contrast, saturation)
+WeatherContrast = 0.25                # Influence of the vanilla contrast setting, applies post-tonemap. Scales atop WeatherModifier, can cause black crush
+Saturation = 1.0                      # Saturation of the image before tonemapping
+ToneMappingColor = 1.0                # Changes the strength of the vanilla tint influence (not fades)
+TonemapContrast = 1.0                 # Contrast setting for Lottes, Uchimura
+TonemapBrightness = 1.0               # Brightness setting for Lottes, Uncharted, Uchimura
+TonemapMidpoint = 1.0                 # Midpoint setting for Lottes Tonemapper (avoid changing), Linear Section Start for Uchimura
+TonemapShoulder = 1.0                 # White Shoulder for Lottes (max 1.0, should be left default), Black shoulder for Uchimura
+TonemapWhitePoint = 1.0               # White point Setting for Lottes, Reinhard (both), Uncharted. Adjust point that the image clips/exceeds max brightness. For Uchimura, adjusts Linear Section Length (soft clips whites)
+HighlightSaturation = 1.0             # Highlight saturation for VT Lottes, controls how saturated bright elements are as they approach the White Point
+BloomExponent = 1.5                   # Makes the bloom more spread out or more focused
+BloomStrength = 0.75                   # Scales the game's bloom pass strength
+PointLightMultiplier = 1.0            # Experimental - modifies the strength of all point lights
+
+
+[_Shaders.Tonemapping.Interiors]
+TonemappingMode = 1                   # Tonemapping Algorithm -  0: None (vanilla), 1: VTLottes (default), 2:NVRLottes, 3:Reinhard, 4: Reinhard Jodie, 5: ACES Filmic, 6: ACES Fitted, 7:Uncharted 2, 8:Uchimura (GT), 9:AGX
+Exposure = 1.0                        # Scales the engine lighting strength/brightness range before tonemap, useful for HDR rendering
+Gamma = 2.2                           # Gamma modifier to be applied after tonemapping, delinearises output. If placed at 1.0, outputs at linear space for HDR (UI unaffected)
+Linearization = 2.2                   # Converts image to corrected linear space before tonemapping. 1.0 is non-linear, if so place Gamma at 1.0 as well
+SkyMultiplier = 1.0                   # Scales the brightness of the sky/sun textures. Requires Sky shader enabled
+WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers (brightness, contrast, saturation)
+WeatherContrast = 0.25                # Influence of the vanilla contrast setting, applies post-tonemap. Scales atop WeatherModifier, can cause black crush notably in Interiors
+Saturation = 1.0                      # Saturation of the image before tonemapping
+ToneMappingColor = 1.0                # Changes the strength of the vanilla tint influence (not fades)
+TonemapContrast = 1.0                 # Contrast setting for Lottes, Uchimura
+TonemapBrightness = 1.0               # Brightness setting for Lottes, Uncharted, Uchimura
+TonemapMidpoint = 1.0                 # Midpoint setting for Lottes Tonemapper (avoid changing), Linear Section Start for Uchimura
+TonemapShoulder = 1.0                 # White Shoulder for Lottes (max 1.0, should be left default), Black shoulder for Uchimura
+TonemapWhitePoint = 1.0               # White point Setting for Lottes, Reinhard (both), Uncharted. Adjust point that the image clips/exceeds max brightness. For Uchimura, adjusts Linear Section Length (soft clips whites)
+HighlightSaturation = 1.0             # Highlight saturation for VT Lottes, controls how saturated bright elements are as they approach the White Point
 BloomExponent = 1.0                   # Makes the bloom more spread out or more focused
 BloomStrength = 1.0                   # Scales the game's bloom pass strength
-Exposure = 1.0                        # Scales the lighting strength before tonemap
-Gamma = 2.2                           # Gamma modifier to be applied after tonemapping
-Linearization = 2.2
 PointLightMultiplier = 1.0            # Experimental - modifies the strength of all point lights
+
+
+[_Shaders.Tonemapping.Night]
+TonemappingMode = 1                   # Tonemapping Algorithm -  0: None (vanilla), 1: VTLottes (default), 2:NVRLottes, 3:Reinhard, 4: Reinhard Jodie, 5: ACES Filmic, 6: ACES Fitted, 7:Uncharted 2, 8:Uchimura (GT), 9:AGX
+Exposure = 1.0                        # Scales the engine lighting strength/brightness range before tonemap, useful for HDR rendering
+Gamma = 2.2                           # Gamma modifier to be applied after tonemapping, delinearises output. If placed at 1.0, outputs at linear space for HDR (UI unaffected)
+Linearization = 2.2                   # Converts image to corrected linear space before tonemapping. 1.0 is non-linear, if so place Gamma at 1.0 as well
+SkyMultiplier = 1.0                   # Scales the brightness of the sky/sun textures. Requires Sky shader enabled
+WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers (brightness, contrast, saturation)
+WeatherContrast = 0.25                # Influence of the vanilla contrast setting, applies post-tonemap. Scales atop WeatherModifier, can cause black crush notably in Interiors
 Saturation = 1.0                      # Saturation of the image before tonemapping
-SkyMultiplier = 1.1                   # Scales the brightness of the sky and sky textures. Requires Sky shader enabled
-ToneMapping = 1.0                     # Unused
-ToneMappingBlur = 0.0                 # Unused
-ToneMappingColor = 0.3                # Changes the strength of the vanilla weather tint influence
-TonemappingMode = 4                   # Changes the tonemapping algorithm. 0: raw buffer, 1: game native, 2:ACES, 3:Reinhard, 4: Lotte, 5: ACES Fitted, 6:Uncharted
-WhitePoint = 100.0                    # White point setting for Lotte/Reinhard tonemapper. Changes the value of the brightest pixels
-LotteContrast = 0.5                   # Contrast setting for Lotte Tonemapper
-LotteBrightness = 2.4                 # Brightness setting for Lotte Tonemapper
-LotteMidpoint = 1.2                   # Midpoint setting for Lotte Tonemapper
-LotteShoulder = 20.0                  # Curve shape towards white point for Lotte Tonemapper
-WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers
-
-
-[_Shaders.HDR.Interiors]
+ToneMappingColor = 1.0                # Changes the strength of the vanilla tint influence (not fades)
+TonemapContrast = 1.0                 # Contrast setting for Lottes, Uchimura
+TonemapBrightness = 1.0               # Brightness setting for Lottes, Uncharted, Uchimura
+TonemapMidpoint = 1.0                 # Midpoint setting for Lottes Tonemapper (avoid changing), Linear Section Start for Uchimura
+TonemapShoulder = 1.0                 # White Shoulder for Lottes (max 1.0, should be left default), Black shoulder for Uchimura
+TonemapWhitePoint = 1.0               # White point Setting for Lottes, Reinhard (both), Uncharted. Adjust point that the image clips/exceeds max brightness. For Uchimura, adjusts Linear Section Length (soft clips whites)
+HighlightSaturation = 1.0             # Highlight saturation for VT Lottes, controls how saturated bright elements are as they approach the White Point
 BloomExponent = 1.0                   # Makes the bloom more spread out or more focused
 BloomStrength = 1.0                   # Scales the game's bloom pass strength
-Exposure = 1.0                        # Scales the lighting strength before tonemap
-Gamma = 2.2                           # Gamma modifier to be applied after tonemapping
-Linearization = 2.2
 PointLightMultiplier = 1.0            # Experimental - modifies the strength of all point lights
-Saturation = 1.0                      # Saturation of the image before tonemapping
-SkyMultiplier = 1.0                   # Scales the brightness of the sky and sky textures. Requires Sky shader enabled
-ToneMapping = 1.0                     # Unused
-ToneMappingBlur = 0.0                 # Unused
-ToneMappingColor = 0.4                # Changes the strength of the vanilla weather tint influence
-TonemappingMode = 4                   # Changes the tonemapping algorithm. 0: raw buffer, 1: game native, 2:ACES, 3:Reinhard, 4: Lotte, 5: ACES Fitted, 6:Uncharted
-WhitePoint = 100.0                    # White point setting for Lotte/Reinhard tonemapper. Changes the value of the brightest pixels
-LotteContrast = 1.3                   # Contrast setting for Lotte Tonemapper
-LotteBrightness = 2.0                 # Brightness setting for Lotte Tonemapper
-LotteMidpoint = 1.3                   # Midpoint setting for Lotte Tonemapper
-LotteShoulder = 40.0                   # Curve shape towards white point for Lotte Tonemapper
-WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers
 
 
-[_Shaders.HDR.Night]
-BloomExponent = 0.7                   # Makes the bloom more spread out or more focused
-BloomStrength = 1.5                   # Scales the game's bloom pass strength
-Exposure = 0.7                        # Scales the lighting strength before tonemap
-Gamma = 2.2                           # Gamma modifier to be applied after tonemapping
-Linearization = 2.2
-PointLightMultiplier = 1.0            # Experimental - modifies the strength of all point lights
-Saturation = 1.0                      # Saturation of the image before tonemapping
-SkyMultiplier = 0.5                   # Scales the brightness of the sky and sky textures. Requires Sky shader enabled
-ToneMapping = 1.0                     # Unused
-ToneMappingBlur = 0.0                 # Unused
-ToneMappingColor = 0.5                # Changes the strength of the vanilla weather tint influence
-TonemappingMode = 4                   # Changes the tonemapping algorithm. 0: raw buffer, 1: game native, 2:ACES, 3:Reinhard, 4: Lotte, 5: ACES Fitted, 6:Uncharted
-WhitePoint = 100.0                    # White point setting for Lotte/Reinhard tonemapper. Changes the value of the brightest pixels
-LotteContrast = 1.2                   # Contrast setting for Lotte Tonemapper
-LotteBrightness = 0.0                 # Brightness setting for Lotte Tonemapper
-LotteMidpoint = 0.8                   # Midpoint setting for Lotte Tonemapper
-LotteShoulder = 2.0                   # Curve shape towards white point for Lotte Tonemapper
-WeatherModifier = 1.0                 # Influence of the vanilla weather modifiers
-
-
-[_Shaders.HDR.Status]
-Enabled = true                        # Replaces HDR tonemapping shaders with custom ones.
+[_Shaders.Tonemapping.Status]
+Enabled = true                        # Replaces vanilla HDR tonemapping shaders with custom ones.
 
 
 [_Shaders.ImageAdjust.Main]
 Brightness = 1.0                      # Overall image brightness.
-Saturation = 0.7                      # Overall image saturation.
+Saturation = 1.0                      # Overall image saturation.
 Contrast = 1.0                        # Overall image contrast.
-Strength = 0.4                        # Strength of the effect.
-DarkColorR = 0.9                      # Red channel multiplier for darker tones.
-DarkColorG = 0.7                      # Green channel multiplier for darker tones.
-DarkColorB = 0.7                      # Blue channel multiplier for darker tones.
+Strength = 1.0                        # Strength of the effect.
+DarkColorR = 1.0                      # Red channel multiplier for darker tones.
+DarkColorG = 1.0                      # Green channel multiplier for darker tones.
+DarkColorB = 1.0                      # Blue channel multiplier for darker tones.
 LightColorR = 1.0                     # Red channel multiplier for lighter tones.
 LightColorG = 1.0                     # Green channel multiplier for lighter tones.
 LightColorB = 1.0                     # Blue channel multiplier for lighter tones.
 
 [_Shaders.ImageAdjust.Night]
-Brightness = 1.1                      # Overall image brightness.
-Saturation = 0.8                      # Overall image saturation.
-Contrast = 1.2                        # Overall image contrast.
-Strength = 0.8                        # Strength of the effect.
-DarkColorR = 0.8                      # Red channel multiplier for darker tones.
-DarkColorG = 0.8                      # Green channel multiplier for darker tones.
+Brightness = 1.0                      # Overall image brightness.
+Saturation = 1.0                      # Overall image saturation.
+Contrast = 1.0                        # Overall image contrast.
+Strength = 1.0                        # Strength of the effect.
+DarkColorR = 1.0                      # Red channel multiplier for darker tones.
+DarkColorG = 1.0                      # Green channel multiplier for darker tones.
 DarkColorB = 1.0                      # Blue channel multiplier for darker tones.
-LightColorR = 1.1                     # Red channel multiplier for lighter tones.
-LightColorG = 1.1                     # Green channel multiplier for lighter tones.
-LightColorB = 0.8                     # Blue channel multiplier for lighter tones.
+LightColorR = 1.0                     # Red channel multiplier for lighter tones.
+LightColorG = 1.0                     # Green channel multiplier for lighter tones.
+LightColorB = 1.0                     # Blue channel multiplier for lighter tones.
 
 [_Shaders.ImageAdjust.Interiors]
 Brightness = 1.0                      # Overall image brightness.
 Saturation = 1.0                      # Overall image saturation.
 Contrast = 1.0                        # Overall image contrast.
-Strength = 0.7                        # Strength of the effect.
-DarkColorR = 0.9                      # Red channel multiplier for darker tones.
-DarkColorG = 0.8                      # Green channel multiplier for darker tones.
-DarkColorB = 1.2                      # Blue channel multiplier for darker tones.
+Strength = 1.0                        # Strength of the effect.
+DarkColorR = 1.0                      # Red channel multiplier for darker tones.
+DarkColorG = 1.0                      # Green channel multiplier for darker tones.
+DarkColorB = 1.0                      # Blue channel multiplier for darker tones.
 LightColorR = 1.0                     # Red channel multiplier for lighter tones.
 LightColorG = 1.0                     # Green channel multiplier for lighter tones.
-LightColorB = 0.7                     # Blue channel multiplier for lighter tones.
+LightColorB = 1.0                     # Blue channel multiplier for lighter tones.
 
 [_Shaders.ImageAdjust.Status]
 Enabled = true                        # Basic Image adjustment controls.
@@ -423,9 +423,9 @@ Enabled = true                        # Basic Image adjustment controls.
 
 [_Shaders.Lens.Main]
 DirtLensAmount = 0.4                  # Global effect strength multiplier.
-ExteriorBloomTreshold = 0.65          # Treshold for the max brightness to trigger the effect in exteriors.
-NightBloomTreshold = 0.2              # Treshold for the max brightness to trigger the effect at night.
-InteriorBloomTreshold = 0.2           # Treshold for the max brightness to trigger the effect in interiors.
+ExteriorBloomTreshold = 0.7           # Treshold for the max brightness to trigger the effect in exteriors.
+NightBloomTreshold = 0.1              # Treshold for the max brightness to trigger the effect at night.
+InteriorBloomTreshold = 0.6           # Treshold for the max brightness to trigger the effect in interiors.
 
 [_Shaders.Lens.Status]
 Enabled = true                        # Simulates lens smudges refracting light around brightest areas of the screen.
@@ -512,7 +512,7 @@ Trees = true                         # Wether to include Trees when rendering sh
 [_Shaders.ShadowsExteriors.Main]
 PostProcess = true                   # Wether to render shadows as a post process effect. Currently the only supported mode.
 BlurShadowMaps = true                # Blur shadow maps for soft shadows.
-Darkness = 0.6                       # Darkness of shadows.
+Darkness = 0.5                       # Darkness of shadows.
 Enabled = true                       # Enable sun shadows using rendered shadow maps.
 NightMinDarkness = 0.3               # Darkness of shadows during dark moon phase. Set to 0 to disable shadows completely when there is no moon.
 Quality = 2                          # Not used.
@@ -573,9 +573,9 @@ Terrain = true                       # Wether to include Terrain when rendering 
 Trees = true                         # Wether to include Trees when rendering ortho map.
 
 [_Shaders.ShadowsExteriors.ScreenSpace]
-BlurRadius = 1.0                     # Blur strength for denoising screenspace shadows
+BlurRadius = 5.0                     # Blur strength for denoising screenspace shadows
 Enabled = true                       # Wether to render screen space contact/detail shadows
-RenderDistance = 80000               # Max distance at which to compute screen space shadows
+RenderDistance = 12000               # Max distance at which to compute screen space shadows
 
 [_Shaders.ShadowsExteriors.Status]
 Enabled = true                       # Post process sun and pointlights shadows in exteriors.
@@ -640,7 +640,7 @@ SunsetB = 0.03                      # Color boost for sunset/sunrise sun color (
 [_Shaders.Sky.Clouds]
 UseNormals = false                  # EXPERIMENTAL-Uses the R & G channels of the clouds texture to calculate normals for lighting. Requires special textures
 SphericalNormals = true             # EXPERIMENTAL-Uses this setting if the normals of the clouds point to the center of the panoramic texture
-Transparency = 0.8                  # Clouds base transparency
+Transparency = 0.9                  # Clouds base transparency
 Brightness = 1.0                    # Clouds base brightness
 
 [_Shaders.Sky.Status]
@@ -669,12 +669,12 @@ Enabled = true                      # Snow accumulation on the floor during snow
 [_Shaders.Specular.Exterior]
 BlurMultiplier = 1.0                # Blur strength for detail smoothing.
 DistanceFade = 30000                # Max distance at which the effects will be displayed. Doesn't apply to sky tint.
-FresnelStrength = 0.7               # Strength for the grazing surface lighting boost called fresnel.
+FresnelStrength = 1.0               # Strength for the grazing surface lighting boost called fresnel.
 Glossiness = 16                     # Higher value will make the specular effect affect more intensely a smaller region.
-SkyTintSaturation = 1.8             # Saturation of the sky lighting effect. Sky lighting is based on sky color. 
-SkyTintStrength = 1.0               # Strength for the sky lighting effect. This mostly affects horizontal, dark areas outside.
-SpecLumaTreshold = 0.5              # Treshold for the luma of areas affected by the specular boost.
-SpecularStrength = 0.7              # Strength of the effect for specular boost.
+SkyTintSaturation = 1.0             # Saturation of the sky lighting effect. Sky lighting is based on sky color. 
+SkyTintStrength = 0.5               # Strength for the sky lighting effect. This mostly affects horizontal, dark areas outside.
+SpecLumaTreshold = 0.7              # Treshold for the luma of areas affected by the specular boost.
+SpecularStrength = 0.3              # Strength of the effect for specular boost.
 
 [_Shaders.Specular.Rain]
 BlurMultiplier = 3.0                # Blur strength for detail smoothing during rainy weathers.
@@ -683,8 +683,8 @@ FresnelStrength = 1.0               # Strength for the grazing surface lighting 
 Glossiness = 7                      # Higher value will make the specular effect affect more intensely a smaller region during rainy weathers.
 SkyTintSaturation = 1.0             # Saturation of the sky lighting effect. Sky lighting is based on sky color during rainy weathers. 
 SkyTintStrength = 0.1               # Strength for the sky lighting effect during rainy weathers. This mostly affects horizontal, dark areas outside.
-SpecLumaTreshold = 0.1              # Treshold for the luma of areas affected by the specular boost during rainy weathers.
-SpecularStrength = 4.0              # Strength of the effect for specular boost during rainy weathers.
+SpecLumaTreshold = 0.6              # Treshold for the luma of areas affected by the specular boost during rainy weathers.
+SpecularStrength = 1.3              # Strength of the effect for specular boost during rainy weathers.
 
 [_Shaders.Specular.Status]
 Enabled = true                      # Shader that boosts a few lighting effects: specular boost, sky lighting and fresnel boost.

--- a/Extra/NewVegasReloaded.dll.defaults.toml
+++ b/Extra/NewVegasReloaded.dll.defaults.toml
@@ -294,12 +294,12 @@ Enabled = false                       # Not currently used. Replaces grass shade
 [_Shaders.GodRays.Main]
 DayMultiplier = 0.5                   # Strength of godrays during the day.
 LightShaftPasses = 8                  # Not used.
-Luminance = 0.9                       # Treshold for minimum luminosity of areas casting rays. Lower means more of the sky will cast rays.
+Luminance = 0.7                       # Treshold for minimum luminosity of areas casting rays. Lower means more of the sky will cast rays.
 NightMultiplier = 1.0                 # Strength of godrays during the night.
 RayDensity = 0.5                      # Curve for reduction of the intensity of godrays near the sunglare.
 RayIntensity = 1.0                    # Multiplier for the intensity of the bright areas being blurred to create the rays.
 RayLength = 1.0                       # Multiplier for the length of rays.
-RayVisibility = 4.0                   # Exponent for the godrays contrast.
+RayVisibility = 5.0                   # Exponent for the godrays contrast.
 SunGlareEnabled = true                # Strength of the effect will be scaled with the weather sunglare setting.
 TimeEnabled = true                    # Strength of the effect will be strongest around sunset/sunrise and not at all during noon.
 
@@ -627,9 +627,10 @@ Enabled = false                     # Not currently used. Replaces the skin shad
 
 
 [_Shaders.Sky.Main]
-AthmosphereThickness = 1.0          # Determins the height of the athmosphere on the horizon
-SunInfluence = 1.0                  # How wide a side of the athmosphere will the sky lit up.
-SunStrength = 1.0                   # How strong is the sun brighness when reflected by athmosphere
+AthmosphereThickness = 2.0          # Determins the height of the athmosphere on the horizon
+SunInfluence = 2.0                  # How wide a side of the athmosphere will the sky lit up.
+SunStrength = 2.0                   # How strong is the sun brighness when reflected by athmosphere
+GlareStrength = 1.0                 # How much influence does the Sun have over Glare, inversed
 StarStrength = 1.0                  # Multiplier for stars brightness
 ReplaceSun = false                  # Replaces vanilla sun by a procedural sun for whatever reason
 SunsetR = 0.5                       # Color boost for sunset/sunrise sun color (Red)
@@ -640,7 +641,7 @@ SunsetB = 0.03                      # Color boost for sunset/sunrise sun color (
 [_Shaders.Sky.Clouds]
 UseNormals = false                  # EXPERIMENTAL-Uses the R & G channels of the clouds texture to calculate normals for lighting. Requires special textures
 SphericalNormals = true             # EXPERIMENTAL-Uses this setting if the normals of the clouds point to the center of the panoramic texture
-Transparency = 0.9                  # Clouds base transparency
+Transparency = 1.0                  # Clouds base transparency
 Brightness = 1.0                    # Clouds base brightness
 
 [_Shaders.Sky.Status]
@@ -673,8 +674,8 @@ FresnelStrength = 1.0               # Strength for the grazing surface lighting 
 Glossiness = 16                     # Higher value will make the specular effect affect more intensely a smaller region.
 SkyTintSaturation = 1.0             # Saturation of the sky lighting effect. Sky lighting is based on sky color. 
 SkyTintStrength = 0.5               # Strength for the sky lighting effect. This mostly affects horizontal, dark areas outside.
-SpecLumaTreshold = 0.7              # Treshold for the luma of areas affected by the specular boost.
-SpecularStrength = 0.3              # Strength of the effect for specular boost.
+SpecLumaTreshold = 0.2              # Treshold for the luma of areas affected by the specular boost.
+SpecularStrength = 1.0              # Strength of the effect for specular boost.
 
 [_Shaders.Specular.Rain]
 BlurMultiplier = 3.0                # Blur strength for detail smoothing during rainy weathers.
@@ -683,8 +684,8 @@ FresnelStrength = 1.0               # Strength for the grazing surface lighting 
 Glossiness = 7                      # Higher value will make the specular effect affect more intensely a smaller region during rainy weathers.
 SkyTintSaturation = 1.0             # Saturation of the sky lighting effect. Sky lighting is based on sky color during rainy weathers. 
 SkyTintStrength = 0.1               # Strength for the sky lighting effect during rainy weathers. This mostly affects horizontal, dark areas outside.
-SpecLumaTreshold = 0.6              # Treshold for the luma of areas affected by the specular boost during rainy weathers.
-SpecularStrength = 1.3              # Strength of the effect for specular boost during rainy weathers.
+SpecLumaTreshold = 0.2              # Treshold for the luma of areas affected by the specular boost during rainy weathers.
+SpecularStrength = 2.0              # Strength of the effect for specular boost during rainy weathers.
 
 [_Shaders.Specular.Status]
 Enabled = true                      # Shader that boosts a few lighting effects: specular boost, sky lighting and fresnel boost.

--- a/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCIN.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCIN.pso.hlsl
@@ -49,34 +49,36 @@ struct VS_OUTPUT {
 
 VS_OUTPUT main(VS_INPUT IN) {
     VS_OUTPUT OUT;
-
+    
     // scale bloom while maintaining color
     float4 bloom = tex2D(ScreenSpace, IN.ScreenOffset.xy);
-    // float maxBloom = max(bloom.r, max(bloom.g, bloom.b));
+    //float maxBloom = max(bloom.r, max(bloom.g, bloom.b));
     // float4 ratio = bloom / maxBloom;
     // bloom.rgb = TESR_HDRBloomData.x * pows(max(maxBloom, 0), TESR_HDRBloomData.y) * ratio;
-    bloom.rgb = TESR_HDRBloomData.x * pows(max(bloom.rgb, 0), TESR_HDRBloomData.y);
+    bloom.rgb = TESR_HDRBloomData.x * pows(max(bloom.rgb, 0.0), TESR_HDRBloomData.y);
 
-    float4 hdrImage = tex2D(DestBlend, IN.texcoord_1.xy); 
-    float3 final = pows(hdrImage.rgb, 1/TESR_ToneMapping.w) * TESR_HDRData.y; // linearize & exposure
-
-    float HDR = HDRParam.x; // brights cutoff?
-    float q0 = 1.0 / max(bloom.w, HDR);
-    final = ((q0 * HDR) * final) + max(bloom.rgb * (q0 * 0.5), 0); // blend image and bloom
+    float gammaCorrection = max(1.0, TESR_ToneMapping.w);
+    float4 hdrImage = tex2D(DestBlend, IN.texcoord_1.xy);
+    
+    float3 final = pows(hdrImage.rgb, gammaCorrection); // linearize
 
     float screenluma = luma(final);
     final = lerp(screenluma.xxx, final, Cinematic.x * TESR_HDRData.z); // saturation
+    final = lerp(final.rgb, Tint.rgb * luma(final.rgb), saturate(Tint.a * TESR_ToneMapping.z)); // apply tint
+    
+    float q0 = 1.0 / max(bloom.w, HDRParam.x); // HDRParam.x, brights cutoff?
+    final = ((q0 * HDRParam.x) * final) + max(bloom.rgb * (q0 * 0.5), 0.0); // blend image and bloom
+    
+    final = lerp(final.rgb, final.rgb * Cinematic.z, TESR_HDRData.z); // apply brightness from Cinematic
+    final = tonemap(final.rgb * TESR_HDRData.y); // exposure & tonemap using provided tonemapper
+    
+    final = pows(final.rgb, 1.0/max(1.0, TESR_HDRData.w)); // delinearise
+    
+    final = lerp(final.rgb, Cinematic.z * (final.rgb - Cinematic.y) + Cinematic.y, TESR_HDRData.z * TESR_ToneMapping.y); // apply contrast from Cinematic, scaled by modifier
+    final = lerp(final.rgb, Fade.rgb, Fade.a); // apply night eye and fade, gamma-space but vanilla-accurate
 
-    final = tonemap(final);
- 
-    screenluma = saturate(luma(final));
-    final = lerp(final, Tint.rgb, Tint.a * TESR_ToneMapping.z); // apply tint
-    // final *= lerp(1, Fade.rgb, lerp(Fade.a, 0, screenluma)); // apply night eye only to darker parts of the scene to avoid dulling bloom
-    final = lerp(final, Fade.rgb, Fade.a); // apply night eye only to darker parts of the scene to avoid dulling bloom
-
-    OUT.color_0.rgb = pows(final.rgb, TESR_HDRData.w);
+    OUT.color_0.rgb = final;
     OUT.color_0.a = BlurScale.z;
-    //OUT.color_0.a = 1;
 
     return OUT;
 };

--- a/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCIN.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCIN.pso.hlsl
@@ -75,7 +75,7 @@ VS_OUTPUT main(VS_INPUT IN) {
     final = pows(final.rgb, 1.0/max(1.0, TESR_HDRData.w)); // delinearise
     
     final = lerp(final.rgb, Cinematic.z * (final.rgb - Cinematic.y) + Cinematic.y, TESR_HDRData.z * TESR_ToneMapping.y); // apply contrast from Cinematic, scaled by modifier
-    final = lerp(final.rgb, Fade.rgb, Fade.a); // apply night eye and fade, gamma-space but vanilla-accurate
+    final = lerp(final.rgb, Fade.rgb, Fade.a); // apply night eye and fade, gamma-space but vanilla accurate
 
     OUT.color_0.rgb = final;
     OUT.color_0.a = BlurScale.z;

--- a/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCINAM.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/ISHDRBLENDINSHADERCINAM.pso.hlsl
@@ -77,7 +77,7 @@ VS_OUTPUT main(VS_INPUT IN) {
     final = pows(final.rgb, 1.0/max(1.0, TESR_HDRData.w)); // delinearise
     
     final = lerp(final.rgb, Cinematic.z * (final.rgb - Cinematic.y) + Cinematic.y, TESR_HDRData.z * TESR_ToneMapping.y); // apply contrast from Cinematic, scaled by modifier
-    final = lerp(final.rgb, Fade.rgb, Fade.a); // apply night eye and fade, gamma-space but vanilla-accurate
+    final = lerp(final.rgb, Fade.rgb, Fade.a); // apply night eye and fade, gamma-space but vanilla accurate
 
     float4 background = tex2D(DestBlend, IN.ScreenOffset.xy); // sdr image (already tonemapped) displayed within the mask
     OUT.color_0.rgb = (background.w == 0 ? background.rgb : final); //only tonemap the area within the mask

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Sky.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Sky.hlsl
@@ -2,14 +2,14 @@
 float3 GetSunColor(float sunHeight, float athmosphere, float dayTime, float3 sunColor, float3 sunsetColor ){
     float3 color = (1 + sunHeight) * sunColor; // increase suncolor strength with sun height
     float sunSet = saturate(pows(1 - sunHeight, 8.0)) * dayTime;
-    color += sunsetColor.rgb * sunSet * athmosphere; // add extra red to the sun at sunsets
+    color = mix(color.rgb, sunsetColor.rgb * sunSet * athmosphere); // add extra red to the sun at sunsets
     return color;
 }
 
 float3 GetSkyColor(float verticality, float athmosphere, float sunHeight, float sunInfluence, float sunStrength, float3 skyColor, float3 skyLowColor, float3 horizonColor, float3 sunColor){
     float3 color = lerp(skyLowColor.rgb, skyColor.rgb, verticality); // fade from low sky to high sky with height
     color = lerp(color, horizonColor.rgb, saturate(athmosphere * (0.5 + sunInfluence * 0.5))); // fade from base color to horizon color in athmosphere (stronger on the sun side)
-    color += sunColor * sunInfluence * (1 - sunHeight) * (((1 - verticality) + athmosphere)/2) * sunStrength * 0.5;
+    color = mix(color, sunColor * sunInfluence * (1.0 - sunHeight) * (((1.0 - verticality) + athmosphere)/2) * sunStrength);
 
     return color;
 }

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Sky.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Sky.hlsl
@@ -9,7 +9,7 @@ float3 GetSunColor(float sunHeight, float athmosphere, float dayTime, float3 sun
 float3 GetSkyColor(float verticality, float athmosphere, float sunHeight, float sunInfluence, float sunStrength, float3 skyColor, float3 skyLowColor, float3 horizonColor, float3 sunColor){
     float3 color = lerp(skyLowColor.rgb, skyColor.rgb, verticality); // fade from low sky to high sky with height
     color = lerp(color, horizonColor.rgb, saturate(athmosphere * (0.5 + sunInfluence * 0.5))); // fade from base color to horizon color in athmosphere (stronger on the sun side)
-    color += sunColor * sunInfluence * (1 - sunHeight) * (((1 - verticality) + athmosphere)/2) * sunStrength * 0.4;
+    color += sunColor * sunInfluence * (1 - sunHeight) * (((1 - verticality) + athmosphere)/2) * sunStrength * 0.5;
 
     return color;
 }

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
@@ -225,7 +225,7 @@ float3 VTLottes(float3 color, float contrast, float midOut, float midIn, float h
 {
     hdrMax = max(1.0, hdrMax * 100.0);
     contrast = max(0.01, contrast * 1.35);
-    shoulder = saturate(0.993); // shoulder should not! exceed 1.0
+    shoulder = saturate(shoulder * 0.993); // shoulder should not! exceed 1.0
     midIn = max(0.01, midIn * 0.18);
     midOut = max(0.01, midOut * 0.18);
 	
@@ -264,7 +264,7 @@ float3 Lottes(float3 x, float contrast, float midOut, float midIn, float hdrMax,
 {
     hdrMax = max(1.0, hdrMax * 100.0);
     contrast = max(0.01, contrast * 1.35);
-    shoulder = saturate(0.993); // shoulder should not! exceed 1.0
+    shoulder = saturate(shoulder * 0.993); // shoulder should not! exceed 1.0
     midIn = max(0.01, midIn * 0.18);
     midOut = max(0.01, midOut * 0.18);
 

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
@@ -241,7 +241,7 @@ float3 VTLottes(float3 color, float contrast, float midOut, float midIn, float h
     // then process ratio
 
     // probably want send these pre-computed (so send over saturation/crossSaturation as a constant)
-    float crosstalk = max(1.0,crossTalk * 3.0); // controls amount of channel crosstalk
+    float crosstalk = max(1.0,crossTalk * 4.0); // controls amount of channel crosstalk
     float saturation = contrast; // full tonal range saturation control
     float crossSaturation = contrast * (64.0 / crosstalk); // crosstalk saturation
 

--- a/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Includes/Tonemapping.hlsl
@@ -1,11 +1,12 @@
 // ACES tonemapping https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
-float3 ACESFilm(float3 x) {
-	float a = 2.51f;
-	float b = 0.03f;
-	float c = 2.43f;
-	float d = 0.59f;
-	float e = 0.14f;
-	return (x*(a*x+b))/(x*(c*x+d)+e);
+float3 ACESFilm(float3 x)
+{
+    float a = 2.51f;
+    float b = 0.03f;
+    float c = 2.43f;
+    float d = 0.59f;
+    float e = 0.14f;
+    return (x * (a * x + b)) / (x * (c * x + d) + e);
 }
 
 // -----------------------------------------------------------------------------------------------
@@ -15,17 +16,17 @@ float3 ACESFilm(float3 x) {
 // sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
 static const float3x3 ACESInputMat =
 {
-    {0.59719, 0.35458, 0.04823},
-    {0.07600, 0.90834, 0.01566},
-    {0.02840, 0.13383, 0.83777}
+    { 0.59719, 0.35458, 0.04823 },
+    { 0.07600, 0.90834, 0.01566 },
+    { 0.02840, 0.13383, 0.83777 }
 };
 
 // ODT_SAT => XYZ => D60_2_D65 => sRGB
 static const float3x3 ACESOutputMat =
 {
-    { 1.60475, -0.53108, -0.07367},
-    {-0.10208,  1.10813, -0.00605},
-    {-0.00327, -0.07276,  1.07602}
+    { 1.60475, -0.53108, -0.07367 },
+    { -0.10208, 1.10813, -0.00605 },
+    { -0.00327, -0.07276, 1.07602 }
 };
 
 float3 RRTAndODTFit(float3 v)
@@ -35,6 +36,7 @@ float3 RRTAndODTFit(float3 v)
     return a / b;
 }
 
+// ACES Filmic (Fitted)
 float3 ACESFitted(float3 color)
 {
     color = mul(ACESInputMat, color);
@@ -51,74 +53,316 @@ float3 ACESFitted(float3 color)
 }
 // -----------------------------------------------------------------------------------------------
 
-
-// https://64.github.io/tonemapping/
-float3 Reinhard(float3 x, float whitepoint) {
-    float luminance = luma(x);
-    float tonemappedLuma = luminance * (1 + luminance / (float(whitepoint * whitepoint)))/(1 + luminance);
-    return x * (tonemappedLuma / luminance).rrr;
+// Reinhard-Jodie (color+luminance)
+float3 ReinhardJodie(float3 v)
+{
+    float l = luma(v);
+    float3 tv = v / (1.0f + v);
+    return lerp(v / (1.0f + l), tv, tv);
 }
 
-float3 Uncharted2Tonemap(float3 x) {
+// Reinhard (luminance tonemap)
+float3 change_luminance(float3 c_in, float l_out)
+{
+    float l_in = luma(c_in);
+    return c_in * (l_out / l_in);
+}
+float3 ReinhardExtended(float3 v, float whitepoint)
+{
+    whitepoint = max(1.0, whitepoint * 3.0);
+    float l_old = luma(v);
+    float numerator = l_old * (1.0f + (l_old / (whitepoint * whitepoint)));
+    float l_new = numerator / (1.0f + l_old);
+    return change_luminance(v, l_new);
+}
+
+// Uncharted 2 tonemapper
+float3 uncharted2_tonemap_partial(float3 x)
+{
     float A = 0.15;
     float B = 0.50;
     float C = 0.10;
     float D = 0.20;
-    float E = 0.02;
+    float E = 0.01;
     float F = 0.30;
-    float W = 11.2;
-    return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
+    return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
+}
+float3 Uncharted2Tonemap(float3 v, float exposure_bias, float whitepoint)
+{
+    exposure_bias = max(0.1, exposure_bias * 1.4);
+    float3 curr = uncharted2_tonemap_partial(v * exposure_bias);
+    
+    whitepoint = max(1.0, whitepoint * 3.0);
+    float3 white_scale = float3(1.0f, 1.0f, 1.0f) / uncharted2_tonemap_partial(whitepoint);
+    return curr * white_scale;
+}
+
+//AGX
+//https://iolite-engine.com/blog_posts/minimal_agx_implementation
+static const float3x3 agx_mat =
+{
+    { 0.842479062253094, 0.0423282422610123, 0.0423756549057051 },
+    { 0.0784335999999992, 0.878468636469772, 0.0784336 },
+    { 0.0792237451477643, 0.0791661274605434, 0.879142973793104 }
+};
+static const float3x3 agx_mat_inv =
+{
+    { 1.19687900512017, -0.0528968517574562, -0.0529716355144438 },
+    { -0.0980208811401368, 1.15190312990417, -0.0980434501171241 },
+    { -0.0990297440797205, -0.0989611768448433, 1.15107367264116 }
+};
+
+// Mean error^2: 3.6705141e-06
+float3 agxDefaultContrastApprox(float3 x)
+{
+    float3 x2 = x * x;
+    float3 x4 = x2 * x2;
+  
+    return +15.5 * x4 * x2
+         - 40.14 * x4 * x
+         + 31.96 * x4
+         - 6.868 * x2 * x
+         + 0.4298 * x2
+         + 0.1191 * x
+         - 0.00232;
+}
+
+float3 agxEotf(float3 val)
+{
+    
+  // Inverse input transform (outset)
+    val = mul(agx_mat_inv, val);
+  
+  // sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display
+  // NOTE: We're linearizing the output here. Comment/adjust when
+  // *not* using a sRGB render target
+    val = pows(val, 2.2);
+
+    return val;
+}
+
+// 0: Default, 1: Golden, 2: Punchy
+//#define AGX_LOOK 0
+float3 agxLook(float3 val)
+{
+    float3 luma_val = luma(val);
+  
+  // Default
+    float3 offset = 0.0;
+    float3 slope = 1.0;
+    float power = 1.0;
+    float sat = 1.0;
+ 
+//#if AGX_LOOK == 1
+//  // Golden
+//  slope = float3(1.0, 0.9, 0.5);
+//  power = 0.8;
+//  sat = 0.8;
+//#elif AGX_LOOK == 2
+//  // Punchy
+//  slope = 1.0;
+//  power = 1.35;
+//  sat = 1.4;
+//#endif
+  
+  // ASC CDL
+    val = pows(val * slope + offset, power);
+    return luma_val + sat * (val - luma_val);
+}
+
+float3 agx(float3 val)
+{
+    //val = pows(val, 1.0 / 2.2);
+    
+    float min_ev = -12.47393f;
+    float max_ev = 4.026069f;
+
+  // Input transform (inset)
+    val = mul(agx_mat, val);
+  
+  // Log2 space encoding
+    val = clamp(log2(val), min_ev, max_ev);
+    val = (val - min_ev) / (max_ev - min_ev);
+  
+  // Apply sigmoid function approximation
+    val = agxDefaultContrastApprox(val);
+    
+    val = agxLook(val);
+    val = agxEotf(val);
+
+    return val;
+}
+
+// https://gist.github.com/KelSolaar/1213139203911a72fef531c32c3d4ec2
+// https://gist.github.com/vtastek/935be12fb8d87adda751b5276fd88f0c
+// Lottes (2016) adapted by vtastek
+
+
+float ColToneB(float hdrMax, float contrast, float shoulder, float midIn, float midOut)
+{
+    return
+        -((-pows(midIn, contrast) + (midOut * (pows(hdrMax, contrast * shoulder) * pows(midIn, contrast) -
+            pows(hdrMax, contrast) * pows(midIn, contrast * shoulder) * midOut)) /
+            (pows(hdrMax, contrast * shoulder) * midOut - pows(midIn, contrast * shoulder) * midOut)) /
+            (pows(midIn, contrast * shoulder) * midOut));
+}
+
+// General tonemapping operator, build 'c' term.
+float ColToneC(float hdrMax, float contrast, float shoulder, float midIn, float midOut)
+{
+    return (pows(hdrMax, contrast * shoulder) * pows(midIn, contrast) - pows(hdrMax, contrast) * pows(midIn, contrast * shoulder) * midOut) /
+           (pows(hdrMax, contrast * shoulder) * midOut - pows(midIn, contrast * shoulder) * midOut);
+}
+
+// General tonemapping operator, p := {contrast,shoulder,b,c}.
+float ColTone(float x, float4 p)
+{
+    float z = pows(x, p.r);
+    return z / (pows(z, p.g) * p.b + p.a);
+}
+#define CMAX 1.6e+6f
+float3 VTLottes(float3 color, float contrast, float midOut, float midIn, float hdrMax, float shoulder, float crossTalk)
+{
+    hdrMax = max(1.0, hdrMax * 100.0);
+    contrast = max(0.01, contrast * 1.35);
+    shoulder = saturate(0.993); // shoulder should not! exceed 1.0
+    midIn = max(0.01, midIn * 0.18);
+    midOut = max(0.01, midOut * 0.18);
+	
+    float b = ColToneB(hdrMax, contrast, shoulder, midIn, midOut);
+    float c = ColToneC(hdrMax, contrast, shoulder, midIn, midOut);
+
+    #define EPS 1e-6f
+    float peak = max(color.r, max(color.g, color.b));
+    peak = min(CMAX, max(EPS, peak));
+
+    float3 ratio = min(CMAX, color / peak);
+    peak = ColTone(peak, float4(contrast, shoulder, b, c));
+    // then process ratio
+
+    // probably want send these pre-computed (so send over saturation/crossSaturation as a constant)
+    float crosstalk = max(1.0,crossTalk * 3.0); // controls amount of channel crosstalk
+    float saturation = contrast; // full tonal range saturation control
+    float crossSaturation = contrast * (64.0 / crosstalk); // crosstalk saturation
+
+    float3 rgb = 1.0;
+
+    // wrap crosstalk in transform
+    ratio = pows(abs(ratio), saturation / crossSaturation);
+    ratio = lerp(ratio, rgb, pows(peak, crosstalk));
+    ratio = pows(min(CMAX, ratio), crossSaturation);
+
+    // then apply ratio to peak
+    color = peak * ratio;
+
+    return color;
 }
 
 // https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf
-float3 Lottes(float3 x, float contrast, float brightness, float midIn, float hdrMax, float shoulder){
-
-    // scale values for easier tuning
-    float3 params = float3(contrast, brightness, shoulder) * 0.1 + 1.0;
+// Adjusted NVR Lottes, initial algorithm
+float3 Lottes(float3 x, float contrast, float midOut, float midIn, float hdrMax, float shoulder)
+{
+    hdrMax = max(1.0, hdrMax * 100.0);
+    contrast = max(0.01, contrast * 1.35);
+    shoulder = saturate(0.993); // shoulder should not! exceed 1.0
+    midIn = max(0.01, midIn * 0.18);
+    midOut = max(0.01, midOut * 0.18);
 
     // shape of the curve
-    float3 z = pows(x, params.x); // toe (lower part of curve)
+    float3 z = pows(x, contrast); // toe (lower part of curve)
 
     // curve anchor (mid point)
     float2 e = float2(midIn, hdrMax);
-    float2 exp = float2(params.x * params.z, params.x);
+    float2 exp = float2(contrast * shoulder, contrast);
     float4 f = pows(e.xyxy, exp.xxyy);
 
     // clipping/white point
-    float b = -((-f.z + (params.y*(f.y*f.z - f.w * f.z * params.y)) / (f.y*params.y - f.x*params.y)) / (f.x*params.y));
+    float b = -((-f.z + (midOut * (f.y * f.z - f.w * f.z * midOut)) / (f.y * midOut - f.x * midOut)) / (f.x * midOut));
     
     // midOut
-    float c = (f.y*f.z - f.w*f.x*params.y)/(f.y*params.y - f.x*params.y);
+    float c = (f.y * f.z - f.w * f.x * midOut) / (f.y * midOut - f.x * midOut);
 
     // test to tonemap color/brighness separately
     float peak = max(z.r, max(z.g, z.b));
-    float3 ratio = z/peak;
-    return ratio * (peak / (pows(peak, params.z) * b + c));
-    // return z / (pows(z, params.z) * b + c);
+    float3 ratio = z / peak;
+    return ratio * (peak / (pows(peak, shoulder) * b + c));
+    // return z / (pows(z, shoulder) * b + c);
 }
 
-
-// applies the 
-float3 applyCinematic(float3 color){
-    return Cinematic.z * (Cinematic.w * color - Cinematic.y) + Cinematic.y;
+// Uchimura GT Tonemapper
+float3 Uchimura(float3 x, float contrast, float brightness, float midIn, float hdrMax, float shoulder)
+{
+    float P = 1.0 * brightness; // brightness
+    float a = 1.0 * contrast; // contrast
+    float m = 0.05 * midIn; // linear section start
+    float l = 0.05 * hdrMax; // linear section length
+    float3 c = 1.0 + (0.333 * shoulder); // black
+    float b = 0.0; // pedestal
+    
+    float l0 = ((P - m) * l) / a;
+    float L0 = m - m / a;
+    float L1 = m + (1.0 - m) / a;
+    float S0 = m + l0;
+    float S1 = m + a * l0;
+    float C2 = (a * P) / (P - S1);
+    float CP = (-C2) / P;
+    
+    float3 w0 = float3(1.0 - smoothstep(0.0, m, x));
+    float3 w2 = float3(step(m + l0, x));
+    float3 w1 = float3(1.0 - w0 - w2);
+    
+    float3 T = float3(m * pows(x / m, c + b));
+    float3 S = float3(P - (P - S1) * exp(CP * (x - S0)));
+    float3 L = float3(m + a * (x - m));
+    
+    return T * w0 + L * w1 + S * w2;
 }
 
-float3 tonemap(float3 color){
-    color = lerp(color, applyCinematic(color), TESR_HDRBloomData.z);
+float3 tonemap(float3 color)
+{
 
-    if (TESR_HDRData.x == 1){
+    if (TESR_HDRData.x == 0)
+    {
         return color;
-    }else if (TESR_HDRData.x == 2){
+    }
+    else if (TESR_HDRData.x == 1)
+    {
+        return max(0.0, VTLottes(min(CMAX, color), TESR_LotteData.x, TESR_LotteData.y, TESR_LotteData.z, TESR_HDRBloomData.w, TESR_LotteData.w, TESR_ToneMapping.x));
+    }
+    else if (TESR_HDRData.x == 2)
+    {
+        return max(0.0, Lottes(min(CMAX, color), TESR_LotteData.x, TESR_LotteData.y, TESR_LotteData.z, TESR_HDRBloomData.w, TESR_LotteData.w));
+    }
+    else if (TESR_HDRData.x == 3)
+    {
+        return ReinhardExtended(color, TESR_HDRBloomData.w);
+    }
+    else if (TESR_HDRData.x == 4)
+    {
+        return ReinhardJodie(color);
+    }
+    else if (TESR_HDRData.x == 5)
+    {
         return ACESFilm(color);
-    }else if (TESR_HDRData.x == 3){
-        return Reinhard(color, TESR_HDRBloomData.w);
-    }else if (TESR_HDRData.x == 4){
-        return Lottes(color, TESR_LotteData.x, TESR_LotteData.y,  TESR_LotteData.z, TESR_HDRBloomData.w, TESR_LotteData.w);
-    }else if (TESR_HDRData.x == 5){
+    }
+    else if (TESR_HDRData.x == 6)
+    {
         return ACESFitted(color);
-    }else if (TESR_HDRData.x == 6){
-        return Uncharted2Tonemap(color);
-    }else{
+    }
+    else if (TESR_HDRData.x == 7)
+    {
+        return Uncharted2Tonemap(color, TESR_LotteData.y, TESR_HDRBloomData.w);
+    }
+    else if (TESR_HDRData.x == 8)
+    {
+        return Uchimura(color, TESR_LotteData.x, TESR_LotteData.y, TESR_LotteData.z, TESR_HDRBloomData.w, TESR_LotteData.w);
+    }
+    else if (TESR_HDRData.x == 9)
+    {
+        return agx(color);
+    }
+    else
+    {
         return color;
     }
 }

--- a/Extra/Shaders/NewVegasReloaded/Shaders/SKYTEX.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/SKYTEX.pso.hlsl
@@ -129,7 +129,7 @@ VS_OUTPUT main(VS_INPUT IN) {
         float2 normal2D = finalColor.xy; // normal x and y are in red and green, blue is reconstructed
         float3 normal = getNormal(normal2D, -eyeDir); // reconstruct world normal from red and green
 
-        greyScale = lerp(TESR_CloudData.w, 1, finalColor.z); // greyscale is stored in blue channel
+        greyScale = lerp(TESR_CloudData.w, 1.0f, finalColor.z); // greyscale is stored in blue channel
         float3 ambient = skyColor * greyScale * lerp(0.5, 0.7, sunDir); // fade ambient with sun direction
         float3 diffuse = compress(dot(normal, TESR_SunPosition.xyz)) * sunColor * (1 - luma(ambient)) * lerp(0.8, 1, sunDir); // scale diffuse if ambient is high
         float3 fresnel = pows(1 - shade(-eyeDir, normal), 4) * pows(saturate(expand(sunDir)), 2) * shade(normal, up) * (sunColor + skyColor) * 0.2;
@@ -139,8 +139,8 @@ VS_OUTPUT main(VS_INPUT IN) {
         // finalColor.rgb = selectColor(TESR_DebugVar.x, finalColor, ambient, diffuse, fresnel, bounce, scattering, sunColor, skyColor, normal, float3(IN.TexUV, 1));
     } else {
         // simply tint the clouds
-        float sunInfluence = 1 - pow(sunDir, 3.0);
-        float3 cloudTint = lerp(pow(TESR_SkyLowColor.rgb, 5.0), sunColor, saturate(sunInfluence * saturate(greyScale))).rgb;
+        float sunInfluence = 1 - pows(sunDir, 3.0);
+        float3 cloudTint = lerp(pows(TESR_SkyLowColor.rgb, 2.2), sunColor, saturate(sunInfluence * saturate(greyScale))).rgb;
         cloudTint = lerp(cloudTint, white.rgb, sunHeight * TESR_SunAmount.x); // tint the clouds less when the sun is high in the sky
 
         float dayLight = saturate(luma(sunColor));
@@ -149,6 +149,6 @@ VS_OUTPUT main(VS_INPUT IN) {
         finalColor.rgb += scattering;
     }
     
-    OUT.color_0 = float4(finalColor.rgb * IN.color_0.rgb * Params.y, finalColor.w * IN.color_0.a * TESR_CloudData.z) * TESR_SunsetColor.w;
+    OUT.color_0 = float4(finalColor.rgb * IN.color_0.rgb * Params.y, finalColor.w * IN.color_0.a * TESR_CloudData.z) * TESR_SunsetColor.w * 0.915f;
     return OUT;
 };

--- a/NewVegasReloaded/NewVegasReloaded.vcxproj
+++ b/NewVegasReloaded/NewVegasReloaded.vcxproj
@@ -97,6 +97,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -168,7 +168,7 @@ ShaderRecord* ShaderRecord::LoadShader(const char* Name, const char* SubPath) {
 	else if (!memcmp(Name, "GRASS", 5)) {
 		if (!TheSettingManager->GetMenuShaderEnabled("Grass")) return NULL;
 	}
-	else if (!memcmp(Name, "Tonemapping", 3) || !memcmp(Name, "ISHDR", 5)) {
+	else if (!memcmp(Name, "HDR", 3) || !memcmp(Name, "ISHDR", 5)) {
 		// load tonemapping shaders, with different names between New vegas and Oblivion
 		if (!TheSettingManager->GetMenuShaderEnabled("Tonemapping")) return NULL;
 	}
@@ -1044,6 +1044,7 @@ void ShaderManager::UpdateConstants() {
 	if (TheSettingManager->SettingsChanged) {
 		// sky settings are used in several shaders whether the shader is active or not
 		ShaderConst.SunAmount.z = TheSettingManager->GetSettingI("Shaders.Sky.Main", "ReplaceSun");
+		ShaderConst.SunAmount.w = TheSettingManager->GetSettingF("Shaders.Sky.Main", "GlareStrength");
 
 		ShaderConst.Sky.SkyData.x = TheSettingManager->GetSettingF("Shaders.Sky.Main", "AthmosphereThickness");
 		ShaderConst.Sky.SkyData.y = TheSettingManager->GetSettingF("Shaders.Sky.Main", "SunInfluence");
@@ -1899,6 +1900,8 @@ void ShaderManager::RenderEffectsPreTonemapping(IDirect3DSurface9* RenderTarget)
 	// render post process normals for use by shaders
 	RenderEffectToRT(TheTextureManager->NormalsSurface, Effects.Normals, false);
 
+
+
 	// render a shadow pass for point lights
 	if ((isExterior && Effects.ShadowsExteriors->Enabled) || (!isExterior && Effects.ShadowsInteriors->Enabled)) {
 		// separate lights in 2 batches
@@ -1933,6 +1936,7 @@ void ShaderManager::RenderEffectsPreTonemapping(IDirect3DSurface9* RenderTarget)
 
 		if (!PipBoyIsOn) Effects.VolumetricFog->Render(Device, RenderTarget, RenderedSurface, 0, false, NULL);
 	}
+	Effects.GodRays->Render(Device, RenderTarget, RenderedSurface, 0, true, SourceSurface);
 
 	// final adjustments, pre-tonemap once Contrast is adapted
 	//Effects.ImageAdjust->Render(Device, RenderTarget, RenderedSurface, 0, false, SourceSurface);
@@ -1970,7 +1974,6 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 	Device->StretchRect(RenderTarget, NULL, SourceSurface, NULL, D3DTEXF_NONE);
 
 	if (!isUnderwater && isExterior) {
-		Effects.GodRays->Render(Device, RenderTarget, RenderedSurface, 0, true, SourceSurface);
 		if (ShaderConst.Rain.RainData.x > 0.0f) Effects.Rain->Render(Device, RenderTarget, RenderedSurface, 0, false, SourceSurface);
 		if (ShaderConst.Snow.SnowData.x > 0.0f) Effects.Snow->Render(Device, RenderTarget, RenderedSurface, 0, false, NULL);
 	}

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #define FrameFVF D3DFVF_XYZ | D3DFVF_TEX1
+#include <numbers>
 
 
 class Animator {


### PR DESCRIPTION
Corrected Linearisation being inversed (thanks to vtastek), and adapted tonemapping shaders for linear space processing
- Adds VTLottes by vtastek, new default Lottes with pre-tuned parameters and configurable highlight saturation
- Added additional tonemappers including Uchimura, AGX, Reinhard-Jodie
- Corrected settings for regular Reinhard and Uncharted 2 tonemappers
- Adapted all tonemappers to have reasonable defaults scaled by 1.0 multipliers, with limited bounds.
- Reworked Tint's to apply a color atop the luminance of the base image
- Reworked fades to occur in gamma-space post processing (as per vanilla)
- Adapted Cinematic vanilla values to HDR tonemapping, with Brightness/Saturation performed pre-tonemap, and contrast post-tonemap gamma space with a separate scalar
- Renamed several parameters for tonemapping and renamed the HDR section to Tonemapping
- Added prefer speed over size for Release builds
- Adjusted default preset to new Tonemapper setup with alternative defaults
- Godrays made linear and pre-tonemap
- Tonemapping default for Lotte slightly improved
- Specular made linear
- Skies made linear, new defaults and stronger clouds, added separate GlareStrength modifier