### PR TITLE
Use light's geometry list for pointlight shadows

### DIFF
--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -508,13 +508,13 @@ void ShaderManager::DisposeShader(const char* Name) {
 }
 
 
-void ShaderManager::GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLight* LightsList[]) {
+void ShaderManager::GetNearbyLights(ShadowSceneLight* ShadowLightsList[], NiPointLight* LightsList[]) {
 	D3DXVECTOR4 PlayerPosition = Player->pos.toD3DXVEC4();
 	//Logger::Log(" ==== Getting lights ====");
 	auto timer = TimeLogger();
 
 	// create a map of all nearby valid lights and sort them per distance to player
-	std::map<int, NiPointLight*> SceneLights;
+	std::map<int, ShadowSceneLight*> SceneLights;
 	NiTList<ShadowSceneLight>::Entry* Entry = SceneNode->lights.start;
 
 	while (Entry) {
@@ -536,9 +536,9 @@ void ShaderManager::GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLig
 
 		// select lights that will be tracked by removing culled lights and lights behind the player further away than their radius
 		// TODO: handle using frustum check
-		float drawDistance = TheShaderManager->GameState.isExterior ? TheSettingManager->SettingsShadows.Exteriors.ShadowMapRadius[TheShadowManager->ShadowMapTypeEnum::MapLod] : TheSettingManager->SettingsShadows.Interiors.DrawDistance;
+		float drawDistance = 8000;//TheShaderManager->GameState.isExterior ? TheSettingManager->SettingsShadows.Exteriors.ShadowMapRadius[TheShadowManager->ShadowMapTypeEnum::MapLod] : TheSettingManager->SettingsShadows.Interiors.DrawDistance;
 		if ((inFront > 0 || Distance < radius) && (Distance + radius) < drawDistance) {
-			SceneLights[(int)(Distance * 10000)] = Light; // mutliplying distance (used as key) before convertion to avoid duplicates in case of similar values
+			SceneLights[(int)(Distance * 10000)] = Entry->data; // mutliplying distance (used as key) before convertion to avoid duplicates in case of similar values
 		}
 
 		Entry = Entry->next;
@@ -558,10 +558,10 @@ void ShaderManager::GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLig
 
 	D3DXVECTOR4 Empty = D3DXVECTOR4(0, 0, 0, 0);
 
-	std::map<int, NiPointLight*>::iterator v = SceneLights.begin();
+	std::map<int, ShadowSceneLight*>::iterator v = SceneLights.begin();
 	for (int i = 0; i < TrackedLightsMax + ShadowCubeMapsMax; i++) {
 		if (v != SceneLights.end()) {
-			NiPointLight* Light = v->second;
+			NiPointLight* Light = v->second->sourceLight;
 			if (!Light || Light->EffectType != NiDynamicEffect::EffectTypes::POINT_LIGHT) {
 				v++;
 				continue;
@@ -583,7 +583,7 @@ void ShaderManager::GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLig
 
 			if (CastShadow && ShadowIndex < ShadowCubeMapsMax) {
 				// add found light to list of lights that cast shadows
-				ShadowLightsList[ShadowIndex] = Light;
+				ShadowLightsList[ShadowIndex] = v->second;
 				TheShaderManager->ShaderConst.ShadowMap.ShadowLightPosition[ShadowIndex] = LightPos;
 				ShadowIndex++;
 				TheShadowManager->PointLightsNum++; // Constant to track number of shadow casting lights are present

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -71,7 +71,7 @@ public:
 	void					CreateFrameVertex(UInt32 Width, UInt32 Height, IDirect3DVertexBuffer9** FrameVertex);
 	void					InitializeConstants();
 	void					UpdateConstants();
-	void					GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLight* LightsList[]);
+	void					GetNearbyLights(ShadowSceneLight* ShadowLightsList[], NiPointLight* LightsList[]);
 	bool					CreateShader(const char* Name);
 	bool					LoadShader(NiD3DVertexShader* VertexShader);
 	bool					LoadShader(NiD3DPixelShader* PixelShader);

--- a/TESReloaded/Core/ShadowManager.h
+++ b/TESReloaded/Core/ShadowManager.h
@@ -34,7 +34,7 @@ public:
 	void					DrawGeometryBuffer(NiGeometryBufferData* GeoData, UINT verticesCount);
 	void					RenderShadowMap(ShadowMapTypeEnum ShadowMapType, SettingsShadowStruct::ExteriorsStruct* ShadowsExteriors, D3DXVECTOR3* At, D3DXVECTOR4* SunDir);
 	void					RenderExteriorCell(TESObjectCELL* Cell, SettingsShadowStruct::ExteriorsStruct* ShadowsExteriors, ShadowMapTypeEnum ShadowMapType);
-	void					RenderShadowCubeMap(NiPointLight** Lights, int LightIndex, SettingsShadowStruct::InteriorsStruct* ShadowsInteriors);
+	void					RenderShadowCubeMap(ShadowSceneLight** Lights, UInt32 LightIndex, SettingsShadowStruct::InteriorsStruct* ShadowsInteriors);
 	void					RenderShadowMaps();
 	//void					GetNearbyLights(NiPointLight* ShadowLightsList[], NiPointLight* LightsList[]);
 	void					CalculateBlend(NiPointLight** Lights, int LightIndex);

--- a/TESReloaded/Framework/NewVegas/GameNi.h
+++ b/TESReloaded/Framework/NewVegas/GameNi.h
@@ -60,6 +60,7 @@ class BSResizableTriShape;
 class BSShaderTextureSet;
 class EffectShaderProperty;
 class BSRenderPass;
+class BSPortalGraph;
 
 class ShadowSceneLight;
 class AnimSequenceBase;
@@ -1727,6 +1728,20 @@ public:
 };
 assert(sizeof(NiAlphaProperty) == 0x01C);
 
+class NiMaterialProperty : public NiProperty {
+public:
+	SInt32		iIndex;
+	NiColor		spec;
+	NiColor		emit;
+	NiColor*	pExternalEmittance;
+	float		fShine;
+	float		fAlpha;
+	float		fEmitMult;
+	UInt32		uiRevID;
+	void*		pvRendererData;
+};
+assert(sizeof(NiMaterialProperty) == 0x04C);
+
 class NiShadeProperty : public NiProperty {
 public:
 	enum ShaderPropType : UInt32
@@ -1766,7 +1781,7 @@ public:
 	float			unkB0;			// B0
 	float			unkB4;			// B4
 	float			FadeAlpha;		// B8
-	UInt32			unkBC;			// BC
+	float			BoundRadius;	// BC
 	UInt32			unkC0;			// C0
 	UInt32			MultType;		// C4
 	UInt32			unkC8;			// C8
@@ -1812,35 +1827,47 @@ assert(sizeof(BSTreeNode) == 0xF8);
 class ShadowSceneLight : public NiRefObject {
 public:
 
-	UInt32					unk008;				// 008
-	float					flt00C[49];			// 00C
-	float					lightFade;
-	float					unk0D4;
-	float					unk0D8;
-	float					unk0DC;
-	NiTList<NiTriBasedGeom>	lgtList0E0;			// 0E0
-	UInt8					byte0EC;			// 0EC
-	UInt8					byte0ED;			// 0ED
-	UInt8					byte0EE[2];			// 0EE
-	UInt32					unk0F0;				// 0F0
-	UInt32					unk0F4;				// 0F4
-	NiPointLight*			sourceLight;		// 0F8
-	UInt32					unk0FC;				// 0FC
-	NiPoint3				fPosition;			// 100
-	UInt32					unk10C;				// 10C
-	UInt16					bIsEnabled;			// 110
-	UInt16					unk112;				// 112
-	UInt32					unk114;				// 114
-	UInt8					byte118;			// 118
-	UInt8					pad119[3];			// 119
-	float					flt11C;				// 11C
-	float					flt120;				// 120
-	UInt8					byte124;			// 124
-	UInt8					pad125[3];			// 125
-	UInt32					unk128[66];			// 128
-	UInt32					array230[4];		// 230 BSSimpleArray<NiNode>
-	void*					portalGraph;		// 240 BSPortalGraph*
-	UInt32					unk244[3];			// 244
+	UInt32					unk008;
+	float					fLuminance;
+	D3DXMATRIX				kViewProjMatrix;
+	D3DXMATRIX				kViewMatrix;
+	D3DXMATRIX				kProjMatrix;
+	float					fLODDimmer;
+	float					fFade;
+	float					fShadowFadeTime0D8;
+	float					fShadowFadeTime0DC;
+	NiTList<NiGeometry>		kGeometryList;
+	bool					bIsShadowCasting;
+	UInt8					byte0ED;
+	NiAVObject*				spObject0F0;
+	bool					bPointLight;
+	bool					bAmbientLight;
+	NiPointLight*			sourceLight;
+	bool					bDynamicLight;
+	NiPoint3				kPointPosition;
+	UInt32					spShadowRenderTarget;
+	UInt16					bIsEnabled;
+	NiAVObject*				spObject114;
+	bool					bUnk118;
+	float					fUnk11C;
+	float					fUnk120;
+	bool					bShowDebugTexture;
+	NiNode*					spShadowCasterNode;
+	UInt32					kList12C[3];
+	void*					pGeomListFence;
+	void*					spFenceObject;
+	NiCamera*				spShadowMapCamera;
+	NiFrustumPlanes			kFrustumPlanes;
+	float					fClipPlanes[24];
+	bool					bUnk208;
+	BSShaderAccumulator*	spShadowAccum;
+	UInt32					kMultiBoundRooms[4];	// BSSimpleArray<BSMultiBoundRoom*>
+	UInt32					kPortals[4];			// BSSimpleArray<BSPortal*>
+	UInt32					kProcessedNodes[4];		// BSSimpleArray<NiNode>
+	BSPortalGraph*			pPortalGraph;
+	UInt32					unk244;
+	UInt32					unk248;
+	UInt32					unk24C;
 };
 assert(sizeof(ShadowSceneLight) == 0x250);
 


### PR DESCRIPTION
Speeds up shadow cubemap rendering by drawing only geometry that the light hits at (at least according to the game), instead of the whole cell.

Drawbacks are:
- less control over the rendered geometry - we use what game already processed for us
- possible that geometry not using lighting shaders is probably skipped - not 100% sure about this
- no reference data, unless we decide to climb back up to the BSFadeNode of every geometry (assuming there is one) - slow!