### PR TITLE
Add option to disable TESR's shadow management in favour of vanilla.

### DIFF
--- a/resource/NewVegasReloaded.dll.defaults.toml
+++ b/resource/NewVegasReloaded.dll.defaults.toml
@@ -57,6 +57,7 @@ RenderPreTonemapping = true # Toggle rendering of some effects in HDR before the
 ReplaceIntro = false        # Controls rendering of the main menu custom video.
 ScreenshotKey = 87          # Keycode for custom screenshot hotkey (removes HUD and saves as jpg).
 HDRScreenshot = false       # Save screenshots in fbx (use with DXVK HDR)
+DisableShadowManagement = false
 
 [_Main.Main.Precipitations]
 RemovePrecipitations = false   # Disables vanilla rain and other precipitations.

--- a/src/NewVegas/Hooks/Hooks.cpp
+++ b/src/NewVegas/Hooks/Hooks.cpp
@@ -57,10 +57,13 @@ void AttachHooks() {
 	SafeWriteJump(Jumpers::RenderInterface::Hook, (UInt32)RenderInterfaceHook);
 	SafeWriteJump(Jumpers::SetRegionEditorName::Hook, (UInt32)SetRegionEditorNameHook);
 	SafeWriteJump(Jumpers::SetWeatherEditorName::Hook, (UInt32)SetWeatherEditorNameHook);
-	SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook, (UInt32)RenderShadowMapHook);
-	//	SafeWriteJump(Jumpers::Shadows::RenderShadowMap1Hook,		(UInt32)RenderShadowMap1Hook);
-	SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);
-	SafeWriteJump(Jumpers::Shadows::LeavesNodeNameHook, (UInt32)LeavesNodeNameHook);
+	if (!SettingsMain->Main.DisableShadowManagement) {
+		SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook, (UInt32)RenderShadowMapHook);
+		//	SafeWriteJump(Jumpers::Shadows::RenderShadowMap1Hook,		(UInt32)RenderShadowMap1Hook);
+		SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);
+		SafeWriteJump(Jumpers::Shadows::LeavesNodeNameHook, (UInt32)LeavesNodeNameHook);
+	}
+
 	SafeWriteCall(Jumpers::MainMenuMusic::Fix1, (UInt32)MainMenuMusicFix);
 	SafeWriteCall(Jumpers::MainMenuMusic::Fix2, (UInt32)MainMenuMusicFix);
 

--- a/src/NewVegas/Hooks/Hooks.cpp
+++ b/src/NewVegas/Hooks/Hooks.cpp
@@ -57,7 +57,7 @@ void AttachHooks() {
 	SafeWriteJump(Jumpers::RenderInterface::Hook, (UInt32)RenderInterfaceHook);
 	SafeWriteJump(Jumpers::SetRegionEditorName::Hook, (UInt32)SetRegionEditorNameHook);
 	SafeWriteJump(Jumpers::SetWeatherEditorName::Hook, (UInt32)SetWeatherEditorNameHook);
-	if (!SettingsMain->Main.DisableShadowManagement) {
+	if (!(SettingsMain->Main.DisableShadowManagement) ) {
 		SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook, (UInt32)RenderShadowMapHook);
 		//	SafeWriteJump(Jumpers::Shadows::RenderShadowMap1Hook,		(UInt32)RenderShadowMap1Hook);
 		SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);

--- a/src/NewVegas/Hooks/Settings.cpp
+++ b/src/NewVegas/Hooks/Settings.cpp
@@ -15,7 +15,7 @@ bool __fastcall ReadSettingHook(INISettingCollection* This, UInt32 edx, GameSett
 		Setting->pValue = (char*)MainMenuMovie;
 	else if ((!strcmp(Setting->Name, "SMainMenuMusic:General") || !strcmp(Setting->Name, "STitleMusic:Loading")) && TheSettingManager->SettingsMain.Main.ReplaceIntro)
 		Setting->pValue = (char*)MainMenuMusic;
-	else if ((!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display")) && !TheSettingManager->SettingsMain.Main.DisableShadowManagement)
+	else if ((!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display")) && TheSettingManager->SettingsMain.Main.DisableShadowManagement)
 		Setting->iValue = 0;
 	else if (!strcmp(Setting->Name, "iMultiSample:Display") && Setting->iValue < 2 && TheSettingManager->SettingsMain.Main.ForceMSAA)
 		Setting->iValue = 2;

--- a/src/NewVegas/Hooks/Settings.cpp
+++ b/src/NewVegas/Hooks/Settings.cpp
@@ -15,7 +15,7 @@ bool __fastcall ReadSettingHook(INISettingCollection* This, UInt32 edx, GameSett
 		Setting->pValue = (char*)MainMenuMovie;
 	else if ((!strcmp(Setting->Name, "SMainMenuMusic:General") || !strcmp(Setting->Name, "STitleMusic:Loading")) && TheSettingManager->SettingsMain.Main.ReplaceIntro)
 		Setting->pValue = (char*)MainMenuMusic;
-	else if ((!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display")) && TheSettingManager->SettingsMain.Main.DisableShadowManagement)
+	else if ( (!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display") ) && !(TheSettingManager->SettingsMain.Main.DisableShadowManagement))
 		Setting->iValue = 0;
 	else if (!strcmp(Setting->Name, "iMultiSample:Display") && Setting->iValue < 2 && TheSettingManager->SettingsMain.Main.ForceMSAA)
 		Setting->iValue = 2;

--- a/src/NewVegas/Hooks/Settings.cpp
+++ b/src/NewVegas/Hooks/Settings.cpp
@@ -15,7 +15,7 @@ bool __fastcall ReadSettingHook(INISettingCollection* This, UInt32 edx, GameSett
 		Setting->pValue = (char*)MainMenuMovie;
 	else if ((!strcmp(Setting->Name, "SMainMenuMusic:General") || !strcmp(Setting->Name, "STitleMusic:Loading")) && TheSettingManager->SettingsMain.Main.ReplaceIntro)
 		Setting->pValue = (char*)MainMenuMusic;
-	else if (!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display"))
+	else if ((!strcmp(Setting->Name, "bDoCanopyShadowPass:Display") || !strcmp(Setting->Name, "bDoActorShadows:Display") || !strcmp(Setting->Name, "iActorShadowCountExt:Display") || !strcmp(Setting->Name, "iActorShadowCountInt:Display")) && !TheSettingManager->SettingsMain.Main.DisableShadowManagement)
 		Setting->iValue = 0;
 	else if (!strcmp(Setting->Name, "iMultiSample:Display") && Setting->iValue < 2 && TheSettingManager->SettingsMain.Main.ForceMSAA)
 		Setting->iValue = 2;

--- a/src/Oblivion/Hooks/Hooks.cpp
+++ b/src/Oblivion/Hooks/Hooks.cpp
@@ -134,8 +134,10 @@ void AttachHooks() {
 	SafeWriteJump(Jumpers::HitEvent::Hook,						(UInt32)HitEventHook);
 	SafeWriteJump(Jumpers::NewAnimSequenceSingle::Hook,			(UInt32)NewAnimSequenceSingleHook);
 	SafeWriteJump(Jumpers::RemoveSequence::Hook,				(UInt32)RemoveSequenceHook);
-	SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook,		(UInt32)RenderShadowMapHook);
-	SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook,		(UInt32)AddCastShadowFlagHook);
+	if (!SettingsMain->Main.DisableShadowManagement) {
+		SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook, (UInt32)RenderShadowMapHook);
+		SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);
+	}
 //	SafeWriteJump(Jumpers::WaterHeightMap::Hook,				(UInt32)WaterHeightMapHook);
 	SafeWriteJump(Jumpers::EndProcess::Hook,					(UInt32)EndProcessHook);
     

--- a/src/core/SettingManager.cpp
+++ b/src/core/SettingManager.cpp
@@ -370,6 +370,7 @@ void SettingManager::LoadSettings() {
 	SettingsMain.Main.ForceReflections = GetSettingI("Main.Main.Water", "ForceReflections");
 	SettingsMain.Main.MemoryHeapManagement = GetSettingI("Main.Main.Memory", "HeapManagement");
 	SettingsMain.Main.MemoryTextureManagement = GetSettingI("Main.Main.Memory", "TextureManagement");
+	SettingsMain.Main.DisableShadowManagement = GetSettingI("Main.Main.Misc", "DisableShadowManagement");
 	SettingsMain.Main.AnisotropicFilter = GetSettingI("Main.Main.Misc", "AnisotropicFilter");
 	SettingsMain.Main.FarPlaneDistance = GetSettingF("Main.Main.Misc", "FarPlaneDistance");
 	SettingsMain.Main.ScreenshotKey = GetSettingI("Main.Main.Misc", "ScreenshotKey");

--- a/src/core/SettingManager.h
+++ b/src/core/SettingManager.h
@@ -13,6 +13,7 @@ struct SettingsMainStruct {
 		bool	RemovePrecipitations;
 		bool	MemoryHeapManagement;
 		bool	MemoryTextureManagement;
+		bool	DisableShadowManagement;
 		bool	ReplaceIntro;
         bool    SkipFog;
         bool    RenderEffects;


### PR DESCRIPTION
For some people, the Reloaded shadows are an incredibly costly performance hog (this is especially true when using a weaker GPU), and detrimental to the experience with Reloaded.
Unfortunately, due to the way the hook is set up, it is not possible to use Reloaded with the vanilla shadows at the moment.
This PR introduces an option to disable the hook entirely on game start, not exposed on the menu by default, and only able to be toggled through the config file.
Added the check to the OblivionReloaded project too for the sake of consistency.

By default the setting is "DisableShadowManagement", which, while non standard to the settings, as usually the toggle implies a "On/Off" semantic, will ensure that existing presets don't have sudden breakages regarding their shadow settings.